### PR TITLE
Pycon us 2016 cleanup done

### DIFF
--- a/pycon-us-2016/videos/a-jesse-jiryu-davis-write-an-excellent-programming-blog-pycon-2016.json
+++ b/pycon-us-2016/videos/a-jesse-jiryu-davis-write-an-excellent-programming-blog-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: A. Jesse Jiryu Davis\n\nWriting rewards you and benefits us all: when you write you refine your thinking, share your knowledge, and connect with your niche community. This talk describes the special challenges of writing a programming blog. It outlines solid article structures, and offers methods for generating ideas and writing more skillfully. Get the guidance and inspiration to craft articles of enduring value.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1614,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "a-jesse-jiryu-davis-write-an-excellent-programming-blog-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "A. Jesse Jiryu Davis"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/eHXq-IzlGUE/maxresdefault.jpg",
   "title": "Write an Excellent Programming Blog",
   "videos": [
     {
-      "length": 1614,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=eHXq-IzlGUE"
     }

--- a/pycon-us-2016/videos/adrienne-lowe-bake-the-cookies-wear-the-dress-connecting-with-confident-authenticity.json
+++ b/pycon-us-2016/videos/adrienne-lowe-bake-the-cookies-wear-the-dress-connecting-with-confident-authenticity.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Adrienne Lowe\n\nAre you interested in speaking at a tech conference, but you're unsure how you might share relevant technical information in an engaging way? Are you in a position of leadership or mentorship in open source and want to be more approachable, accessible, and collaborative? In a fun and light-hearted talk, learn actionable suggestions for inspiring others with your own confident authenticity.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1954,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "adrienne-lowe-bake-the-cookies-wear-the-dress-connecting-with-confident-authenticity",
@@ -11,14 +10,11 @@
   "speakers": [
     "Adrienne Lowe"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/6Uj746j9Heo/maxresdefault.jpg",
   "title": "Bake the Cookies, Wear the Dress: Connecting with Confident Authenticity",
   "videos": [
     {
-      "length": 1954,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=6Uj746j9Heo"
     }

--- a/pycon-us-2016/videos/alex-gaynor-the-cobblers-children-have-no-shoes-or-building-better-tools-for-ourselves.json
+++ b/pycon-us-2016/videos/alex-gaynor-the-cobblers-children-have-no-shoes-or-building-better-tools-for-ourselves.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Alex Gaynor\n\nAs developers, we make programs which do things. But we don't build nearly enough programs to make our own jobs easier. Once, not all that long ago, we didn't even have continuous integration servers. This talk will go through what types of new specialized tools we, as developers, can and should be building to make our jobs better.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1791,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "alex-gaynor-the-cobblers-children-have-no-shoes-or-building-better-tools-for-ourselves",
@@ -11,14 +10,11 @@
   "speakers": [
     "Alex Gaynor"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/gRFHvavxnos/maxresdefault.jpg",
   "title": "The cobbler's children have no shoes, or building better tools for ourselves",
   "videos": [
     {
-      "length": 1791,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=gRFHvavxnos"
     }

--- a/pycon-us-2016/videos/alex-martelli-exception-and-error-handling-in-python-2-and-python-3-pycon-2016.json
+++ b/pycon-us-2016/videos/alex-martelli-exception-and-error-handling-in-python-2-and-python-3-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Alex Martelli\n\nHandling errors and exceptions optimally is crucial in solid Python programs. Some technical details have changed in Python 3, and the talk covers those, but the core of \"\"best practices\"\" is quite enduring, and the talk focuses on presenting and explaining them.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2799,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "alex-martelli-exception-and-error-handling-in-python-2-and-python-3-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Alex Martelli"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/frZrBgWHJdY/maxresdefault.jpg",
   "title": "Exception and error handling in Python 2 and Python 3",
   "videos": [
     {
-      "length": 2799,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=frZrBgWHJdY"
     }

--- a/pycon-us-2016/videos/allen-downey-bayesian-statistics-made-simple-pycon-2016.json
+++ b/pycon-us-2016/videos/allen-downey-bayesian-statistics-made-simple-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Allen Downey\n\nAn introduction to Bayesian statistics using Python. \u00a0Bayesian statistics are usually presented mathematically, but many of the ideas are easier to understand computationally. \u00a0People who know Python can get started quickly and use Bayesian analysis to solve real problems. \u00a0This tutorial is based on material and case studies from Think Bayes (O\u2019Reilly Media).\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 10644,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-09",
   "related_urls": [],
   "slug": "allen-downey-bayesian-statistics-made-simple-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Allen Downey"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/TpgiFIGXcT4/maxresdefault.jpg",
   "title": "Bayesian statistics made simple",
   "videos": [
     {
-      "length": 10644,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=TpgiFIGXcT4"
     }

--- a/pycon-us-2016/videos/allen-downey-computational-statistics-pycon-2016.json
+++ b/pycon-us-2016/videos/allen-downey-computational-statistics-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Allen Downey\n\nStatistical inference is a fundamental tool in science and engineering, but it is often poorly understood.  This tutorial uses computational methods, including Monte Carlo simulation and resampling, to explore estimation, hypothesis testing and statistical modeling.  Attendees will develop understanding of statistical concepts and learn to use real data to answer relevant questions.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 8959,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "allen-downey-computational-statistics-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Allen Downey"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/VR52vSbHBAk/maxresdefault.jpg",
   "title": "Computational Statistics",
   "videos": [
     {
-      "length": 8959,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=VR52vSbHBAk"
     }

--- a/pycon-us-2016/videos/ana-balica-to-mock-or-not-to-mock-that-is-the-question-pycon-2016.json
+++ b/pycon-us-2016/videos/ana-balica-to-mock-or-not-to-mock-that-is-the-question-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Ana Balica\n\nMocking is a very powerful testing concept that has some dangerous pitfalls. There are obvious use cases where mocks are an absolute requirement to be able to test a part of the app. Nevertheless sometimes apparently useful mocks can yield erroneous test results. This talk goes into deeper detail on the trade-off of using mocks in testing.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1718,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "ana-balica-to-mock-or-not-to-mock-that-is-the-question-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Ana Balica"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/KYG5C1CEkOk/maxresdefault.jpg",
   "title": "To mock, or not to mock, that is the question",
   "videos": [
     {
-      "length": 1718,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=KYG5C1CEkOk"
     }

--- a/pycon-us-2016/videos/andrew-godwin-reinventing-django-for-the-real-time-web-pycon-2016.json
+++ b/pycon-us-2016/videos/andrew-godwin-reinventing-django-for-the-real-time-web-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Andrew Godwin\n\nDjango has long been tied to the request-response pattern, but the upcoming \"\"channels\"\" project changes this and allows Django to natively support WebSockets, running tasks after responses, easily handle long-polling and more. Come and learn about the design, how we're trying to keep things as Django-like as possible, and how you can use it in your projects.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2685,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "andrew-godwin-reinventing-django-for-the-real-time-web-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Andrew Godwin"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/2sEPipctTxw/maxresdefault.jpg",
   "title": "Reinventing Django for the Real-Time Web",
   "videos": [
     {
-      "length": 2685,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=2sEPipctTxw"
     }

--- a/pycon-us-2016/videos/andrey-petrov-see-python-see-python-go-go-python-go-pycon-2016.json
+++ b/pycon-us-2016/videos/andrey-petrov-see-python-see-python-go-go-python-go-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Andrey Petrov\n\nBeing able to run C code from Python is pretty great, but what about running Go code from Python? Or even Python from Go? This talk will walk through the process of executing calls between Python and Go using CFFI bindings to bridge the two runtimes.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1636,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "andrey-petrov-see-python-see-python-go-go-python-go-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Andrey Petrov"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/CkDwb5koRTc/maxresdefault.jpg",
   "title": "See Python, See Python Go, Go Python Go",
   "videos": [
     {
-      "length": 1636,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=CkDwb5koRTc"
     }

--- a/pycon-us-2016/videos/anna-herlihy-wrestling-python-into-llvm-intermediate-representation-pycon-2016.json
+++ b/pycon-us-2016/videos/anna-herlihy-wrestling-python-into-llvm-intermediate-representation-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Anna Herlihy\n\nThe LLVM Project provides an intermediate representation (LLVM-IR) that can be compiled on many platforms. LLVM-IR is used by analytical frameworks to achieve language and platform independence. What if we could add Python to the long list of languages that can be translated to LLVM-IR? This talk will go through the steps of wrestling Python into LLVM-IR with a simple, static one-pass compiler.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1435,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "anna-herlihy-wrestling-python-into-llvm-intermediate-representation-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Anna Herlihy"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/pwO99pcoa9I/maxresdefault.jpg",
   "title": "Wrestling Python into LLVM Intermediate Representation",
   "videos": [
     {
-      "length": 1435,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=pwO99pcoa9I"
     }

--- a/pycon-us-2016/videos/anne-decusatis-more-than-binary-inclusive-gender-collection-and-you-pycon-2016.json
+++ b/pycon-us-2016/videos/anne-decusatis-more-than-binary-inclusive-gender-collection-and-you-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Anne DeCusatis\n\nMany people identify their gender in many ways. So why do we build systems to capture accurate gender information with a dropdown that only lists \u201cmale\u201d and \u201cfemale\u201d?\nThis talk covers why you might want to consider alternative ways of selecting gender for your users, a brief overview of the current best practices, issues addressed by my project Gender Amender, and why more work needs to be done.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1771,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "anne-decusatis-more-than-binary-inclusive-gender-collection-and-you-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Anne DeCusatis"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/iW8ikFrUWPQ/maxresdefault.jpg",
   "title": "More Than Binary: Inclusive Gender Collection and You",
   "videos": [
     {
-      "length": 1771,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=iW8ikFrUWPQ"
     }

--- a/pycon-us-2016/videos/anthony-scopatz-xonsh-pycon-2016.json
+++ b/pycon-us-2016/videos/anthony-scopatz-xonsh-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Anthony Scopatz\n\nXonsh is general purpose shell that combines Python and the best features of Bash, zsh, and fish. Relying only the standard library and PLY, the xonsh language is a strict superset of Python that compiles to a Python AST.  The shell provides exciting features such as a rich history, tab completion from bash and man pages, syntax highlighting, auto-suggestion, foreign-function aliases and more!\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1837,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "anthony-scopatz-xonsh-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Anthony Scopatz"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/uaje5I22kgE/maxresdefault.jpg",
   "title": "xonsh",
   "videos": [
     {
-      "length": 1837,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=uaje5I22kgE"
     }

--- a/pycon-us-2016/videos/ashwini-oruganti-dispelling-the-genius-programmer-myth-through-code-review-pycon-2016.json
+++ b/pycon-us-2016/videos/ashwini-oruganti-dispelling-the-genius-programmer-myth-through-code-review-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Ashwini Oruganti\n\nWe often hear people lament how hard it is to get a patch accepted to large Python open source libraries. Through a series of (often amusing) real-life anecdotes from Twisted, RPython, Cryptography, and examples from many other Python libraries, come learn about code reviews, getting your patches accepted, and tools/processes to encourage quality contributions.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1524,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "ashwini-oruganti-dispelling-the-genius-programmer-myth-through-code-review-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Ashwini Oruganti"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/RR5XHwQB9XU/maxresdefault.jpg",
   "title": "Dispelling the 'Genius Programmer' myth through code review",
   "videos": [
     {
-      "length": 1524,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=RR5XHwQB9XU"
     }

--- a/pycon-us-2016/videos/brett-cannon-dino-viehland-pyjion-who-doesnt-want-faster-for-free-pycon-2016.json
+++ b/pycon-us-2016/videos/brett-cannon-dino-viehland-pyjion-who-doesnt-want-faster-for-free-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speakers: Brett Cannon, Dino Viehland\n\nAt PyCon US 2015 an experiment was started: could a JIT be added to CPython which would speed up performance **and** be fully backwards-compatible? Could unaltered extension modules live happily with a JIT? That experiment is Pyjion and this talk will explain what we changed to CPython to add a pre-existing JIT to it and whether we met our goal of being a benefit instead of a hindrance.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1555,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "brett-cannon-dino-viehland-pyjion-who-doesnt-want-faster-for-free-pycon-2016",
@@ -12,14 +11,11 @@
     "Brett Cannon",
     "Dino Viehland"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/1DAIzO3QXcA/maxresdefault.jpg",
   "title": "Pyjion: who doesn\u2019t want faster for free?",
   "videos": [
     {
-      "length": 1555,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=1DAIzO3QXcA"
     }

--- a/pycon-us-2016/videos/brett-slatkin-refactoring-python-why-and-how-to-restructure-your-code-pycon-2016.json
+++ b/pycon-us-2016/videos/brett-slatkin-refactoring-python-why-and-how-to-restructure-your-code-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Brett Slatkin\n\nAs programs gain complexity, it becomes harder to add features and fix bugs. Reorganizing code is an effective way to make programs more manageable. This talk will show you Pythonic ways to do the most imporant \"\"refactorings\"\": Extract variables with __nonzero__; Change signatures with \\*args and \\*\\*kwargs; Extract fields and classes with @property; Create stateful closures with __call__; and more!\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1823,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-09",
   "related_urls": [],
   "slug": "brett-slatkin-refactoring-python-why-and-how-to-restructure-your-code-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Brett Slatkin"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/D_6ybDcU5gc/maxresdefault.jpg",
   "title": "Refactoring Python: Why and how to restructure your code",
   "videos": [
     {
-      "length": 1823,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=D_6ybDcU5gc"
     }

--- a/pycon-us-2016/videos/brian-corbin-accelerating-healthcare-transactions-with-python-and-pypy-pycon-2016.json
+++ b/pycon-us-2016/videos/brian-corbin-accelerating-healthcare-transactions-with-python-and-pypy-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Brian Corbin\n\nPython is well suited for many file processing tasks. However, Python is an uncommon\nlanguage choice for many organizations that need to process large files of\nhealthcare transactions.  This talk will share lessons we've learned\nprocessing healthcare transactions in Python running on PyPy.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1583,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "brian-corbin-accelerating-healthcare-transactions-with-python-and-pypy-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Brian Corbin"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/aVNaxNDN5ok/maxresdefault.jpg",
   "title": "Accelerating healthcare transactions with Python and PyPy",
   "videos": [
     {
-      "length": 1583,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=aVNaxNDN5ok"
     }

--- a/pycon-us-2016/videos/brian-warner-magic-wormhole-simple-secure-file-transfer-pycon-2016mp4.json
+++ b/pycon-us-2016/videos/brian-warner-magic-wormhole-simple-secure-file-transfer-pycon-2016mp4.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Brian Warner\n\n\"\"magic-wormhole\"\" is a simple tool to move files from one computer to another, like \"\"scp\"\" but without the setup. By telling the recipient just a few secret words, the file is safely encrypted and delivered directly to the correct machine. The talk will explain the security mechanics, the cryptography (NaCl and SPAKE2), and how to use the underlying open-source library in your own applications.\n\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2003,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-20",
   "related_urls": [],
   "slug": "brian-warner-magic-wormhole-simple-secure-file-transfer-pycon-2016mp4",
@@ -11,14 +10,11 @@
   "speakers": [
     "Brian Warner"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/oFrTqQw0_3c/maxresdefault.jpg",
   "title": "Magic Wormhole- Simple Secure File Transfer",
   "videos": [
     {
-      "length": 2003,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=oFrTqQw0_3c"
     }

--- a/pycon-us-2016/videos/chelsea-voss-oneliner-izer-an-exercise-in-constrained-coding-pycon-2016.json
+++ b/pycon-us-2016/videos/chelsea-voss-oneliner-izer-an-exercise-in-constrained-coding-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Chelsea Voss\n\nWe'll describe the ideas and implementation behind Oneliner-izer, a \"\"compiler\"\" which can convert most Python 2 programs into one line of code. As we discuss how to construct each language feature within this unorthodox constraint, we'll explore the boundaries of what Python permits and encounter some gems of functional programming \u2013\u00a0lambda calculus, continuations, and the Y combinator.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1729,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "chelsea-voss-oneliner-izer-an-exercise-in-constrained-coding-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Chelsea Voss"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/DsUxuz_Rt8g/maxresdefault.jpg",
   "title": "Oneliner-izer: An Exercise in Constrained Coding",
   "videos": [
     {
-      "length": 1729,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=DsUxuz_Rt8g"
     }

--- a/pycon-us-2016/videos/chloe-mawer-trainspotting-real-time-detection-of-a-trains-passing-from-video-pycon-2016.json
+++ b/pycon-us-2016/videos/chloe-mawer-trainspotting-real-time-detection-of-a-trains-passing-from-video-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Chloe Mawer\n\nAlmost anyone can set up their motion detection surveillance using just a few Python functions. This talk will walk through the development of a model used to detect whether a train is passing and in what direction it is going using a real-time video feed. You\u2019ll learn some basic motion detection techniques in Python as well as the effects of video quality on implementation.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1983,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "chloe-mawer-trainspotting-real-time-detection-of-a-trains-passing-from-video-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Chloe Mawer"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/MC00XWdl-ms/maxresdefault.jpg",
   "title": "Trainspotting: real-time detection of a train\u2019s passing from video",
   "videos": [
     {
-      "length": 1983,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=MC00XWdl-ms"
     }

--- a/pycon-us-2016/videos/christian-heimes-file-descriptors-unix-sockets-and-other-posix-wizardry-pycon-2016.json
+++ b/pycon-us-2016/videos/christian-heimes-file-descriptors-unix-sockets-and-other-posix-wizardry-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Christian Heimes\n\nHave you ever wondered how the OS manages open files and network connections, what this 'file descriptor' thing actually is all about, or what's so special about Unix sockets? In my talk I will give you a quick tour into the I/O layer and process model of Unix-like operating systems. You will learn how to securely identify and efficiently share resources between processes.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1922,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "christian-heimes-file-descriptors-unix-sockets-and-other-posix-wizardry-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Christian Heimes"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/Ftg8fjY_YWU/maxresdefault.jpg",
   "title": "File descriptors, Unix sockets and other POSIX wizardry",
   "videos": [
     {
-      "length": 1922,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=Ftg8fjY_YWU"
     }

--- a/pycon-us-2016/videos/christophe-pettus-django-1819-and-postgresql-an-ever-closer-union-pycon-2016.json
+++ b/pycon-us-2016/videos/christophe-pettus-django-1819-and-postgresql-an-ever-closer-union-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Christophe Pettus\n\nDjango 1.8/1.9 adds a whole bunch of cool new features that are specifically designed for PostgreSQL. We'll take a quick tour through them, and show when and how you can use them in real-world applications. We'll also talk about how to get the best performance out of PostgreSQL when using the Django ORM.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2396,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "christophe-pettus-django-1819-and-postgresql-an-ever-closer-union-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Christophe Pettus"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/oeLACa7cj1Q/maxresdefault.jpg",
   "title": "Django 1.8/1.9 and PostgreSQL: An Ever-Closer Union",
   "videos": [
     {
-      "length": 2396,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=oeLACa7cj1Q"
     }

--- a/pycon-us-2016/videos/christophe-pettus-postgresql-proficiency-for-python-people-pycon-2016.json
+++ b/pycon-us-2016/videos/christophe-pettus-postgresql-proficiency-for-python-people-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Christophe Pettus\n\nPostgreSQL has become the default database for most green-field development projects, and is the data storage architecture behind many major Python-based success stories, such as Instagram. Despite a reputation as being complex and fiddly, Postgres is easy to install, administer, maintain, and use... with just a little bit of orientation. This is that orientation.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 10806,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "christophe-pettus-postgresql-proficiency-for-python-people-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Christophe Pettus"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/knUitQQnpJo/maxresdefault.jpg",
   "title": "PostgreSQL Proficiency for Python People",
   "videos": [
     {
-      "length": 10806,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=knUitQQnpJo"
     }

--- a/pycon-us-2016/videos/clara-bennett-git-a-peek-under-the-hood-pycon-2016.json
+++ b/pycon-us-2016/videos/clara-bennett-git-a-peek-under-the-hood-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Clara Bennett\n\nGit is a powerful source control tool, but the learning curve can be steep. This talk introduces the underpinnings of git, to provide a foundation for more confident and effective git use. My hypothesis is that having a solid mental model of what git is actually doing under the hood helps you more easily learn to use advanced git features.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1474,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "clara-bennett-git-a-peek-under-the-hood-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Clara Bennett"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/zZ2hG6PMjk8/maxresdefault.jpg",
   "title": "Git: A Peek Under the Hood",
   "videos": [
     {
-      "length": 1474,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=zZ2hG6PMjk8"
     }

--- a/pycon-us-2016/videos/cory-benfield-building-protocol-libraries-the-right-way-pycon-2016.json
+++ b/pycon-us-2016/videos/cory-benfield-building-protocol-libraries-the-right-way-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Cory Benfield\n\nOne of the great strengths of the Python ecosystem is the enormous collection of powerful, flexible libraries. However, these libraries tend to suffer from one extremely common design flaw that mean that the work done is not easily re-usable or transferable. In this talk, we talk about how to build libraries that can be used as widely as possible, through the lens of the Python Hyper HTTP project.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1897,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "cory-benfield-building-protocol-libraries-the-right-way-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Cory Benfield"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/7cC3_jGwl_U/maxresdefault.jpg",
   "title": "Building Protocol Libraries The Right Way",
   "videos": [
     {
-      "length": 1897,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=7cC3_jGwl_U"
     }

--- a/pycon-us-2016/videos/craig-kerstiens-postgres-present-and-future-pycon-2016.json
+++ b/pycon-us-2016/videos/craig-kerstiens-postgres-present-and-future-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Craig Kerstiens\n\nPostgres 9.5 was just released a few months ago and has a number of of new improvements we'll walk through including new JSONB functions, some analytical tooling, and of course upsert. Then we'll dive into what's coming in Postgres 9.6, the next Postgres release. Finally, we'll round it out with some look at the ecosystem of extensions.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1852,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "craig-kerstiens-postgres-present-and-future-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Craig Kerstiens"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/rYSSX8mdbMk/maxresdefault.jpg",
   "title": "Postgres present and future",
   "videos": [
     {
-      "length": 1852,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=rYSSX8mdbMk"
     }

--- a/pycon-us-2016/videos/creating-building-testing-and-documenting-a-python-project-a-hands-on-howto-pycon-2016.json
+++ b/pycon-us-2016/videos/creating-building-testing-and-documenting-a-python-project-a-hands-on-howto-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speakers: Titus Brown, Luiz Irber\n\nWe will do a hands-on walkthrough of creating a new Python project, showing how to make use of git and GitHub, PyPI, distutils, nosetests, continuous integration, Sphinx, and other resources to support the development, distribution, and documentation of the project in a completely free and open manner.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 11826,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-29",
   "related_urls": [],
   "slug": "creating-building-testing-and-documenting-a-python-project-a-hands-on-howto-pycon-2016",
@@ -12,14 +11,11 @@
     "Titus Brown",
     "Luiz Irber"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/SUt3wT43AeM/maxresdefault.jpg",
   "title": "Creating, building, testing, and documenting a Python project - a hands-on HOWTO",
   "videos": [
     {
-      "length": 11826,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=SUt3wT43AeM"
     }

--- a/pycon-us-2016/videos/cris-ewing-keynote-pycon-2016.json
+++ b/pycon-us-2016/videos/cris-ewing-keynote-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Cris Ewing\n\nKeynote\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2532,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "cris-ewing-keynote-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Cris Ewing"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/eGRJbBI_H2w/maxresdefault.jpg",
   "title": "Keynote",
   "videos": [
     {
-      "length": 2532,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=eGRJbBI_H2w"
     }

--- a/pycon-us-2016/videos/dan-callahan-the-new-mobile-web-service-worker-push-and-app-manifests-pycon-2016.json
+++ b/pycon-us-2016/videos/dan-callahan-the-new-mobile-web-service-worker-push-and-app-manifests-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Dan Callahan\n\nCompared to native apps, mobile websites are at a disadvantage: no installing, no push notifications, and they only work when you're online. This year, that changes.\n\nBrowser vendors are working together to implement open standards that address each of these shortcomings. This session examines how the Service Worker, Push, and App Manifest specifications fill the gap between web and native.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1602,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "dan-callahan-the-new-mobile-web-service-worker-push-and-app-manifests-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Dan Callahan"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/dacOIIqKFfs/maxresdefault.jpg",
   "title": "The New Mobile Web: Service Worker, Push, and App Manifests",
   "videos": [
     {
-      "length": 1602,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=dacOIIqKFfs"
     }

--- a/pycon-us-2016/videos/daniel-riti-remote-calls-local-calls-graceful-degradation-when-services-fail-pycon-2016.json
+++ b/pycon-us-2016/videos/daniel-riti-remote-calls-local-calls-graceful-degradation-when-services-fail-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Daniel Riti\n\nIn a world where we are becoming more dependent on the network to be reliable due to trends to decouple systems into distributed services, we must do our best to expect failure to occur everywhere and anywhere. This talks aims to explore different techniques for gracefully degrading when the networks fail and the services we depend on are no longer available.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1846,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "daniel-riti-remote-calls-local-calls-graceful-degradation-when-services-fail-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Daniel Riti"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/dY-SkuENZP8/maxresdefault.jpg",
   "title": "Remote Calls != Local Calls: Graceful Degradation when Services Fail",
   "videos": [
     {
-      "length": 1846,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=dY-SkuENZP8"
     }

--- a/pycon-us-2016/videos/daniele-procida-documentation-driven-development-lessons-from-the-django-project-pycon-2016.json
+++ b/pycon-us-2016/videos/daniele-procida-documentation-driven-development-lessons-from-the-django-project-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Daniele Procida\n\nOne secret of Django's success is the quality of its documentation. As well as being key to the quality of the code itself, it has helped drive the development of Django as a community project, and even the professional development of programmers who adopt Django.\n\nI'll discuss how Django has achieved it, and how any project can easily win the same benefits.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1748,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-17",
   "related_urls": [],
   "slug": "daniele-procida-documentation-driven-development-lessons-from-the-django-project-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Daniele Procida"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/bQSR1UpUdFQ/maxresdefault.jpg",
   "title": "Documentation-driven development - lessons from the Django Project",
   "videos": [
     {
-      "length": 1748,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=bQSR1UpUdFQ"
     }

--- a/pycon-us-2016/videos/dave-sawyer-sqlite-gotchas-and-gimmes-pycon-2016.json
+++ b/pycon-us-2016/videos/dave-sawyer-sqlite-gotchas-and-gimmes-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Dave Sawyer\n\nPython's sqlite module provides access to the most deployed database engine\nin the world. We'll go beyond the docs to discover how to unlock the full\npower of SQLite without additional libraries. We'll identify deadly\npitfalls and produce clean Pythonic code. Find out why the creators say to\nthink of SQLite not as a replacement for Oracle, but as a replacement for\nopen().\n\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1511,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "dave-sawyer-sqlite-gotchas-and-gimmes-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Dave Sawyer"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/D7wSMnapDp4/maxresdefault.jpg",
   "title": "SQLite: Gotchas and Gimmes",
   "videos": [
     {
-      "length": 1511,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=D7wSMnapDp4"
     }

--- a/pycon-us-2016/videos/davey-shafik-http2-and-asynchronous-apis-pycon-2016.json
+++ b/pycon-us-2016/videos/davey-shafik-http2-and-asynchronous-apis-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Davey Shafik\n\nHTTP/2 (H2) is coming, and along with it a whole new way of communicating over the web. Connection re-use, prioritization, multiplexing, and server push are just some of the features in H2, and they will change how the web works.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1755,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "davey-shafik-http2-and-asynchronous-apis-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Davey Shafik"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/Mou17XxYRZk/maxresdefault.jpg",
   "title": "HTTP/2 and Asynchronous APIs",
   "videos": [
     {
-      "length": 1755,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=Mou17XxYRZk"
     }

--- a/pycon-us-2016/videos/david-baumgold-get-started-with-git-pycon-2016.json
+++ b/pycon-us-2016/videos/david-baumgold-get-started-with-git-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: David Baumgold\n\nYou want to learn Git, but you don't know where to start. Or maybe you're already using Git, but you know you're not using it to its full potential. With this tutorial, you'll level up from Git novice to Git wizard, learning how to master your version control system, travel through time, and change history.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 10838,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-09",
   "related_urls": [],
   "slug": "david-baumgold-get-started-with-git-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "David Baumgold"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/RrdECLvHW6g/maxresdefault.jpg",
   "title": "Get Started with Git",
   "videos": [
     {
-      "length": 10838,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=RrdECLvHW6g"
     }

--- a/pycon-us-2016/videos/david-baumgold-prototyping-new-apis-with-flask-pycon-2016.json
+++ b/pycon-us-2016/videos/david-baumgold-prototyping-new-apis-with-flask-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: David Baumgold\n\nYou need to build a new API, but which tools do you use? Flask is a microframework that makes web development a snap, and an ecosystem of extensions and other tools has grown around it to make it perfect for prototyping APIs. In this talk, we'll see how to get started with Flask, and learn the best parts of its ecosystem for API development.\n\nSlides can be found at: https://speakerdeck.com/singingwolfbo... and there is a GitHub repository for the code here: https://github.com/singingwolfboy/bui...\n\nhttps://us.pycon.org/2016/schedule/pr...",
   "duration": 1411,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "david-baumgold-prototyping-new-apis-with-flask-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "David Baumgold"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/6RdZNiyISVU/maxresdefault.jpg",
   "title": "Prototyping New APIs with Flask",
   "videos": [
     {
-      "length": 1411,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=6RdZNiyISVU"
     }

--- a/pycon-us-2016/videos/deploying-and-scaling-applications-with-docker-swarm-and-a-tiny-bit-of-python-magic-pycon-2016.json
+++ b/pycon-us-2016/videos/deploying-and-scaling-applications-with-docker-swarm-and-a-tiny-bit-of-python-magic-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: J\u00e9r\u00f4me Petazzoni\n\nDocker is an open platform to build, ship, and run any application, anywhere. In this hands-on tutorial, you will learn advanced Docker concepts, and see how to deploy and scale applications using Docker Swarm clustering abilities and reusable, customizable Python tooling.\n\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 11466,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "deploying-and-scaling-applications-with-docker-swarm-and-a-tiny-bit-of-python-magic-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "J\u00e9r\u00f4me Petazzoni"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/GpHMTR7P2Ms/maxresdefault.jpg",
   "title": "Deploying and scaling applications with Docker, Swarm, and a tiny bit of Python magic",
   "videos": [
     {
-      "length": 11466,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=GpHMTR7P2Ms"
     }

--- a/pycon-us-2016/videos/dorian-pula-pythons-in-a-container-lessons-learned-dockerizing-python-micro-services.json
+++ b/pycon-us-2016/videos/dorian-pula-pythons-in-a-container-lessons-learned-dockerizing-python-micro-services.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Dorian Pula\n\nMicro-services and Docker are all the rage for developing scalable systems.  But what challenges will you face when developing and deploying Python apps using Docker to production? This talk goes into the real-life lessons learned from creating, deploying and scaling Dockerized Python applications.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1826,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "dorian-pula-pythons-in-a-container-lessons-learned-dockerizing-python-micro-services",
@@ -11,14 +10,11 @@
   "speakers": [
     "Dorian Pula"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/qT0dQ8S7jOg/maxresdefault.jpg",
   "title": "Pythons in A Container - Lessons Learned Dockerizing Python Micro-Services",
   "videos": [
     {
-      "length": 1826,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=qT0dQ8S7jOg"
     }

--- a/pycon-us-2016/videos/drew-fisher-designing-secure-systems-with-object-capabilities-python-and-capn-proto.json
+++ b/pycon-us-2016/videos/drew-fisher-designing-secure-systems-with-object-capabilities-python-and-capn-proto.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Drew Fisher\n\nObject-capability security is a technique for designing systems that lets us apply object-oriented design principles to security policies, reducing cognitive overhead and risk of errors that lead to vulnerabilities.  In this talk, I'll explain capabilities, how they work, and what cool things they make possible for your systems, with real-world examples from sandstorm.io.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1667,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "drew-fisher-designing-secure-systems-with-object-capabilities-python-and-capn-proto",
@@ -11,14 +10,11 @@
   "speakers": [
     "Drew Fisher"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/OS94twkD74s/maxresdefault.jpg",
   "title": "Designing secure systems with Object-Capabilities, Python, and Cap'n Proto",
   "videos": [
     {
-      "length": 1667,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=OS94twkD74s"
     }

--- a/pycon-us-2016/videos/dustin-ingram-what-is-and-what-can-be-an-exploration-from-type-to-metaclasses-pycon-2016.json
+++ b/pycon-us-2016/videos/dustin-ingram-what-is-and-what-can-be-an-exploration-from-type-to-metaclasses-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Dustin Ingram\n\nMost of us use `type` every day, but few can say they know it well. This talk explores `type` and along the way, reveals how it relates to `object`, `class` and more, eventually arriving at deeper understanding of metaclasses in Python.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1194,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "dustin-ingram-what-is-and-what-can-be-an-exploration-from-type-to-metaclasses-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Dustin Ingram"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/bI0JUY2qd2A/maxresdefault.jpg",
   "title": "What Is and What Can Be: An Exploration from `type` to Metaclasses",
   "videos": [
     {
-      "length": 1194,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=bI0JUY2qd2A"
     }

--- a/pycon-us-2016/videos/dwight-hubbard-keeping-cool-using-a-raspberry-pi-to-create-a-networked-temperature-sensor.json
+++ b/pycon-us-2016/videos/dwight-hubbard-keeping-cool-using-a-raspberry-pi-to-create-a-networked-temperature-sensor.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Dwight Hubbard\n\nWant to keep things cool?  Come learn how to build a networked temperature sensor using a Raspberry PI, some simple hardware, and Python.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2032,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-16",
   "related_urls": [],
   "slug": "dwight-hubbard-keeping-cool-using-a-raspberry-pi-to-create-a-networked-temperature-sensor",
@@ -11,14 +10,11 @@
   "speakers": [
     "Dwight Hubbard"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/KKC3MjRCueQ/hqdefault.jpg",
   "title": "Keeping cool, using a Raspberry PI to create a networked temperature sensor",
   "videos": [
     {
-      "length": 2032,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=KKC3MjRCueQ"
     }

--- a/pycon-us-2016/videos/elana-hashman-teaching-python-the-hard-parts-pycon-2016.json
+++ b/pycon-us-2016/videos/elana-hashman-teaching-python-the-hard-parts-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Elana Hashman\n\nSo you want to share the love and start teaching Python? It's dangerous to go alone! In this talk, I will share some of my experience teaching Python to newcomers of all levels and issues I've encountered. I hope to raise your awareness of some of the pitfalls different beginner Python programmers encounter, giving you some tools to help you build curriculum and answer difficult student questions.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2309,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "elana-hashman-teaching-python-the-hard-parts-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Elana Hashman"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/CjYEpVNbM-s/maxresdefault.jpg",
   "title": "Teaching Python: The Hard Parts",
   "videos": [
     {
-      "length": 2309,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=CjYEpVNbM-s"
     }

--- a/pycon-us-2016/videos/elizabeth-ramirez-kalman-filters-for-non-rocket-science-pycon-2016mp4.json
+++ b/pycon-us-2016/videos/elizabeth-ramirez-kalman-filters-for-non-rocket-science-pycon-2016mp4.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Elizabeth Ramirez\n\nKalman Filters have been widely used for scientific applications. No wonder people often think they involve complex math, however you can actually introduce the Kalman Filter in your daily data processing work, without the complex math you would imagine. This talk will show how to implement the discrete Kalman Filter in Python using NumPy and SciPy.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1802,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-17",
   "related_urls": [],
   "slug": "elizabeth-ramirez-kalman-filters-for-non-rocket-science-pycon-2016mp4",
@@ -11,14 +10,11 @@
   "speakers": [
     "Elizabeth Ramirez"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/k_MpfzMc9PU/maxresdefault.jpg",
   "title": "Kalman Filters for non-rocket science",
   "videos": [
     {
-      "length": 1802,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=k_MpfzMc9PU"
     }

--- a/pycon-us-2016/videos/elizabeth-uselton-small-batch-artisanal-bots-lets-make-friends-pycon-2016mp4.json
+++ b/pycon-us-2016/videos/elizabeth-uselton-small-batch-artisanal-bots-lets-make-friends-pycon-2016mp4.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Elizabeth Uselton\n\nBots are a fun, creative, community oriented project. They are perfect for a beginning programmer looking to build something cool, but open ended enough to hold the interest of an experienced developer. In this talk we'll go over the Python tools for building a great twitter bot, including where to find fun data sets, hosting your bot, delayed jobs, and examples of weird and wonderful bots.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 444,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-17",
   "related_urls": [],
   "slug": "elizabeth-uselton-small-batch-artisanal-bots-lets-make-friends-pycon-2016mp4",
@@ -11,14 +10,11 @@
   "speakers": [
     "Elizabeth Uselton"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/iU9FM9qnEjk/maxresdefault.jpg",
   "title": "Small Batch Artisanal Bots- Let's Make Friends",
   "videos": [
     {
-      "length": 444,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=iU9FM9qnEjk"
     }

--- a/pycon-us-2016/videos/eric-holscher-documenting-your-project-with-sphinx-read-the-docs-pycon-2016.json
+++ b/pycon-us-2016/videos/eric-holscher-documenting-your-project-with-sphinx-read-the-docs-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Eric Holscher\n\nThis tutorial will cover how to write documentation using RST, Sphinx, and publish it on Read the Docs. It will walk users through the experience of taking a basic module, writing multiple pages of documentation for it, and then publishing it for the world to see. We'll learn about the mental model required to write documentation, specifically ho\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 9656,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-29",
   "related_urls": [],
   "slug": "eric-holscher-documenting-your-project-with-sphinx-read-the-docs-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Eric Holscher"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/hM4I58TA72g/maxresdefault.jpg",
   "title": "Documenting your project with Sphinx & Read the Docs",
   "videos": [
     {
-      "length": 9656,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=hM4I58TA72g"
     }

--- a/pycon-us-2016/videos/eric-j-ma-practical-network-analysis-made-simple-pycon-2016.json
+++ b/pycon-us-2016/videos/eric-j-ma-practical-network-analysis-made-simple-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Eric J. Ma\n\nHave you ever wondered about how those data scientists at Facebook and LinkedIn make friend recommendations? Or how epidemiologists track down patient zero in an outbreak? If so, then this tutorial is for you. In this upgraded version of last year's tutorial, we will explore a variety of network analysis problems, including graph construction, traversal, and statistics.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 9614,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-29",
   "related_urls": [],
   "slug": "eric-j-ma-practical-network-analysis-made-simple-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Eric J. Ma"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/jdvlZJKK4F0/maxresdefault.jpg",
   "title": "Practical Network Analysis Made Simple",
   "videos": [
     {
-      "length": 9614,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=jdvlZJKK4F0"
     }

--- a/pycon-us-2016/videos/felix-crux-what-you-need-to-know-about-open-source-licenses-pycon-2016.json
+++ b/pycon-us-2016/videos/felix-crux-what-you-need-to-know-about-open-source-licenses-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Felix Crux\n\nAnyone who uses Open Source has run into software licenses. Too often, our understanding of this mess of legalese is incomplete, confused, or based on bad assumptions. But we can\u2019t ignore them: licenses govern everything about how we use others\u2019 code \u2014 and how they use ours. Come learn the basics of copyright, what different licenses let you do, and why & how you should choose one for your code!\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2524,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-17",
   "related_urls": [],
   "slug": "felix-crux-what-you-need-to-know-about-open-source-licenses-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Felix Crux"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/9kGrKBOytYM/maxresdefault.jpg",
   "title": "What You Need to Know About Open Source Licenses",
   "videos": [
     {
-      "length": 2524,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=9kGrKBOytYM"
     }

--- a/pycon-us-2016/videos/final-remarks-and-conference-close.json
+++ b/pycon-us-2016/videos/final-remarks-and-conference-close.json
@@ -1,22 +1,18 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "",
   "duration": 891,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "final-remarks-and-conference-close",
   "source_url": "https://www.youtube.com/watch?v=fAyUF7i8RyI",
   "speakers": [],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/fAyUF7i8RyI/maxresdefault.jpg",
   "title": "Final Remarks and Conference Close",
   "videos": [
     {
-      "length": 891,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=fAyUF7i8RyI"
     }

--- a/pycon-us-2016/videos/geoff-gerrietts-diving-into-the-wreck-a-postmortem-look-at-real-world-performance-pycon-2016.json
+++ b/pycon-us-2016/videos/geoff-gerrietts-diving-into-the-wreck-a-postmortem-look-at-real-world-performance-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Geoff Gerrietts\n\nAs a young engineer interested in performance, much of the advice I saw on performance management focused on algorithms and rules of thumb. It\u2019s good advice, but it doesn\u2019t address the most common problems. This talk will cover a handful of the most common performance problems I\u2019ve encountered in my career. We will talk about how to recognize them, what causes them, and how to resolve them.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1685,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "geoff-gerrietts-diving-into-the-wreck-a-postmortem-look-at-real-world-performance-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Geoff Gerrietts"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/yHpy4Khx0Ds/maxresdefault.jpg",
   "title": "Diving into the Wreck: a postmortem look at real-world performance",
   "videos": [
     {
-      "length": 1685,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=yHpy4Khx0Ds"
     }

--- a/pycon-us-2016/videos/giles-hall-laser-cutters-3d-printers-and-python-pycon-2016.json
+++ b/pycon-us-2016/videos/giles-hall-laser-cutters-3d-printers-and-python-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Giles Hall\n\nHow to leverage python to generate physical, tangible things.  We will discuss the basics of laser cutters, 3D printers, and how you can use python to design physical objects.  After a brief introduction to these    technologies, we will explore a few different examples of how we can use python to generate designs suitable for 3D printing and laser cutting.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2267,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-17",
   "related_urls": [],
   "slug": "giles-hall-laser-cutters-3d-printers-and-python-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Giles Hall"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/UwL-ncEr-_I/hqdefault.jpg",
   "title": "Laser Cutters, 3D Printers, and Python",
   "videos": [
     {
-      "length": 2267,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=UwL-ncEr-_I"
     }

--- a/pycon-us-2016/videos/glyph-shipping-software-to-users-with-python-pycon-2016.json
+++ b/pycon-us-2016/videos/glyph-shipping-software-to-users-with-python-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Glyph\n\nPython is a versatile language, available on a wide variety of platforms. However, when it comes to shipping code to users on those platforms, Python violates Zen Rule 13: \u201cThere should be one\u2014and preferably only one\u2014obvious way to do it.\u201d: there are a lot of ways to do it, and many of them are far from obvious.  In this talk I'll show you how to build Python code into something a user can use.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2707,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "glyph-shipping-software-to-users-with-python-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Glyph"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/5BqAeN-F9Qs/maxresdefault.jpg",
   "title": "Shipping Software To Users With Python",
   "videos": [
     {
-      "length": 2707,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=5BqAeN-F9Qs"
     }

--- a/pycon-us-2016/videos/grant-jenks-python-sorted-collections-pycon-2016.json
+++ b/pycon-us-2016/videos/grant-jenks-python-sorted-collections-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Grant Jenks\n\nC++, Java, and .NET provide sorted collections types. Wish Python did too? Look around and you'll find Pandas DataFrame indexes, Sqlite in-memory databases, even redis-py sorted set commands. The SortedContainers module was designed to fill this gap with sorted list, dict and set implementations. It's written in pure-Python but generally faster than C-extension modules. Come see how it works.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2469,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "grant-jenks-python-sorted-collections-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Grant Jenks"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/7z2Ki44Vs4E/maxresdefault.jpg",
   "title": "Python Sorted Collections",
   "videos": [
     {
-      "length": 2469,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=7z2Ki44Vs4E"
     }

--- a/pycon-us-2016/videos/guido-van-rossum-python-language-pycon-2016.json
+++ b/pycon-us-2016/videos/guido-van-rossum-python-language-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Guido van Rossum\n\nPython Language\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2534,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "guido-van-rossum-python-language-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Guido van Rossum"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/YgtL4S7Hrwo/maxresdefault.jpg",
   "title": "Python Language",
   "videos": [
     {
-      "length": 2534,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=YgtL4S7Hrwo"
     }

--- a/pycon-us-2016/videos/guillermo-perez-python-as-a-configuration-language-pycon-2016.json
+++ b/pycon-us-2016/videos/guillermo-perez-python-as-a-configuration-language-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Guillermo P\u00e9rez\n\nThe enormous size of Facebook's infrastructure and its \"\"Move Fast\"\" culture pose a challenge for the configuration framework, requiring a safe, fast and usable system to deploy settings to hundreds of thousands of servers.\n\nPython plays a special role in this framework, being the tool for generating the configuration, paired with thrift for enhanced schema validation and type-safety.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1829,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "guillermo-perez-python-as-a-configuration-language-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Guillermo P\u00e9rez"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/cLWUD9VnLmA/maxresdefault.jpg",
   "title": "Python as a configuration language",
   "videos": [
     {
-      "length": 1829,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=cLWUD9VnLmA"
     }

--- a/pycon-us-2016/videos/harry-percival-outside-in-tdd-pycon-2016.json
+++ b/pycon-us-2016/videos/harry-percival-outside-in-tdd-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Harry Percival\n\nAn intermediate-level Test-Driven-Development workshop, presented as a hands-on exploration of \"\"outside-in\"\" TDD, in the style of a code-dojo code kata.  Will include discussion of \"\"double-loop\"\" BDD/TDD, outside-in vs inside-out, a detailed discussion of the pros + cons of mocking, test isolation, letting the tests drive design, and what are tests for anyway?\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 6420,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-09",
   "related_urls": [],
   "slug": "harry-percival-outside-in-tdd-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Harry Percival"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/6zQAu23bKF8/maxresdefault.jpg",
   "title": "Outside-In TDD",
   "videos": [
     {
-      "length": 6420,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=6zQAu23bKF8"
     }

--- a/pycon-us-2016/videos/how-i-built-a-power-debugger-out-of-the-standard-library-and-things-i-found-on-the-internet.json
+++ b/pycon-us-2016/videos/how-i-built-a-power-debugger-out-of-the-standard-library-and-things-i-found-on-the-internet.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Doug Hellmann\n\nSmiley spys on your application, recording everything it does, using Python's built-in tracing facility and a database to create a complete record of your program's runtime so you can study it. Most of the tools I used to create Smiley are in Python's standard library, and the history of Smiley's development serves as a framework to discuss those tools and how you can tap their power yourself.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1820,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "how-i-built-a-power-debugger-out-of-the-standard-library-and-things-i-found-on-the-internet",
@@ -11,14 +10,11 @@
   "speakers": [
     "Doug Hellmann"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/g8kF9tuYZ6s/maxresdefault.jpg",
   "title": "How I built a power debugger out of the standard library and things I found on the internet",
   "videos": [
     {
-      "length": 1820,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=g8kF9tuYZ6s"
     }

--- a/pycon-us-2016/videos/hynek-schlawack-get-instrumented-how-prometheus-can-unify-your-metrics-pycon-2016.json
+++ b/pycon-us-2016/videos/hynek-schlawack-get-instrumented-how-prometheus-can-unify-your-metrics-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Hynek Schlawack\n\nTo get real time insight into your running applications you need to instrument them and collect metrics: count events, measure times, expose numbers. Sadly this important aspect of development was a patchwork of half-integrated solutions for years. Prometheus changed that and this talk will walk you through instrumenting your apps and servers, building dashboards, and monitoring using metrics.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2495,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "hynek-schlawack-get-instrumented-how-prometheus-can-unify-your-metrics-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Hynek Schlawack"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/b-qLOY5ChnQ/maxresdefault.jpg",
   "title": "Get Instrumented: How Prometheus Can Unify Your Metrics",
   "videos": [
     {
-      "length": 2495,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=b-qLOY5ChnQ"
     }

--- a/pycon-us-2016/videos/improving-learning-resources-and-community-for-deaf-sign-language-users-through-deaf-awareness.json
+++ b/pycon-us-2016/videos/improving-learning-resources-and-community-for-deaf-sign-language-users-through-deaf-awareness.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Sarah Jessica Leivers\n\nDeaf people are underrepresented in programming roles and in the wider CS community. There are extra obstacles that Deaf people face when learning to code and integrating/networking within the industry. Python might be ideal for teaching Deaf people to program, and with the help of some Deaf Aware Pythonistas, the Python community might be the ideal place for Deaf programmers to feel included.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1589,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "improving-learning-resources-and-community-for-deaf-sign-language-users-through-deaf-awareness",
@@ -11,14 +10,11 @@
   "speakers": [
     "Sarah Jessica Leivers"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/2oG-Z7ADV2c/maxresdefault.jpg",
   "title": "Improving Learning Resources and Community for Deaf Sign Language Users through Deaf Awareness",
   "videos": [
     {
-      "length": 1589,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=2oG-Z7ADV2c"
     }

--- a/pycon-us-2016/videos/ipython-notebook-in-data-intensive-communities-accelerating-the-process-of-discovery-pycon-2016.json
+++ b/pycon-us-2016/videos/ipython-notebook-in-data-intensive-communities-accelerating-the-process-of-discovery-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speakers: Frances Haugen, Patrick Phelps\n\nHow does IPython Notebook (also known as Jupyter Notebook) change how data intensive teams work? This talk focuses on how the Search and Ads teams at Yelp adopted IPython notebook and how it changed how analysis is undertaken and communicated. Tradeoffs between ease-of-use and reusable code production will also be discussed along with security implications of adoption in an enterprise context.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1802,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "ipython-notebook-in-data-intensive-communities-accelerating-the-process-of-discovery-pycon-2016",
@@ -12,14 +11,11 @@
     "Frances Haugen",
     "Patrick Phelps"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/5gy6svL1DuU/maxresdefault.jpg",
   "title": "IPython Notebook in Data Intensive Communities: Accelerating the process of Discovery",
   "videos": [
     {
-      "length": 1802,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=5gy6svL1DuU"
     }

--- a/pycon-us-2016/videos/irene-chen-a-beginners-guide-to-deep-learning-pycon-2016.json
+++ b/pycon-us-2016/videos/irene-chen-a-beginners-guide-to-deep-learning-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Irene Chen\n\nWhat is deep learning? It has recently exploded in popularity as a complex and incredibly powerful tool. This talk will present the basic concepts underlying deep learning in understandable pieces for complete beginners to machine learning. We will review the math, code up a simple neural network, and provide contextual background on how deep learning is used in production now.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1854,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-17",
   "related_urls": [],
   "slug": "irene-chen-a-beginners-guide-to-deep-learning-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Irene Chen"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/nCPf8zDJ0d0/hqdefault.jpg",
   "title": "A Beginner's Guide to Deep Learning",
   "videos": [
     {
-      "length": 1854,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=nCPf8zDJ0d0"
     }

--- a/pycon-us-2016/videos/jacob-kovac-revitalizing-python-game-development-packaging-performance-and-platformsmp4.json
+++ b/pycon-us-2016/videos/jacob-kovac-revitalizing-python-game-development-packaging-performance-and-platformsmp4.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Jacob Kovac\n\nWith the advent of mobile platforms, as well as the prevalence of the GPU, Python has fallen almost entirely out of favor with game developers. However, there are some exciting solutions to the major issues being built on top of the Kivy GUI Framework. This talk will cover the recent developments that make it possible to build high quality, cross-platform games in Python.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1730,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-20",
   "related_urls": [],
   "slug": "jacob-kovac-revitalizing-python-game-development-packaging-performance-and-platformsmp4",
@@ -11,14 +10,11 @@
   "speakers": [
     "Jacob Kovac"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/OSvlNh9aQDc/maxresdefault.jpg",
   "title": "Revitalizing Python Game Development- Packaging, Performance, and Platforms",
   "videos": [
     {
-      "length": 1730,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=OSvlNh9aQDc"
     }

--- a/pycon-us-2016/videos/jake-vanderplas-statistics-for-hackers-pycon-2016mp4.json
+++ b/pycon-us-2016/videos/jake-vanderplas-statistics-for-hackers-pycon-2016mp4.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Jake Vanderplas\n\nStatistics has the reputation of being difficult to understand, but using some simple Python skills it can be made much more intuitive. This talk will cover several sampling-based approaches to solving statistical problems, and show you that if you can write a for-loop, you can do statistics.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2445,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-17",
   "related_urls": [],
   "slug": "jake-vanderplas-statistics-for-hackers-pycon-2016mp4",
@@ -11,14 +10,11 @@
   "speakers": [
     "Jake Vanderplas"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/Iq9DzN6mvYA/maxresdefault.jpg",
   "title": "Statistics for Hackers",
   "videos": [
     {
-      "length": 2445,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=Iq9DzN6mvYA"
     }

--- a/pycon-us-2016/videos/jane-davis-user-research-for-non-researchers-pycon-2016.json
+++ b/pycon-us-2016/videos/jane-davis-user-research-for-non-researchers-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Jane Davis\n\nUser research is a great way to avoid wasting your time. It doesn't have to be time-consuming, elaborate, or performed by a UX professional.In this talk, I'll go over why and how to do lightweight research on any product or topic, no matter what your background and training are. I'll focus on the most effective tools for quick research, and some of the common pitfalls.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1918,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "jane-davis-user-research-for-non-researchers-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Jane Davis"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/bCYEyhfJPto/maxresdefault.jpg",
   "title": "User Research for Non-Researchers",
   "videos": [
     {
-      "length": 1918,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=bCYEyhfJPto"
     }

--- a/pycon-us-2016/videos/jay-goel-better-integration-testing-with-cucumber-pycon-2016.json
+++ b/pycon-us-2016/videos/jay-goel-better-integration-testing-with-cucumber-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Jay Goel\n\nOne of the hardest questions to answer is \"\"does my program help the user accomplish their goals?\"\" Whether that person is using our website or a programmer using our library, this talk will describe how to write automated tests which map to tasks our users are trying to accomplish. We will demonstrate specific Python testing libraries and evaluate the pros and cons of this approach to testing.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1550,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "jay-goel-better-integration-testing-with-cucumber-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Jay Goel"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/ZEZBZFi_e88/maxresdefault.jpg",
   "title": "Better Integration Testing with Cucumber",
   "videos": [
     {
-      "length": 1550,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=ZEZBZFi_e88"
     }

--- a/pycon-us-2016/videos/jerome-petazzoni-introduction-to-docker-and-containers-pycon-2016.json
+++ b/pycon-us-2016/videos/jerome-petazzoni-introduction-to-docker-and-containers-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: J\u00e9r\u00f4me Petazzoni\n\nDocker is an open platform to build, ship, and run any application, anywhere. It can be used in many ways: providing clean, isolated development environments; quickly spinning up test instances for CI purposes; ensuring coherence between development and production platform; and much more.\n\nIn this hands-on tutorial, you will learn basic Docker concepts, and use it to run Python applications.\n\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 11354,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "jerome-petazzoni-introduction-to-docker-and-containers-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "J\u00e9r\u00f4me Petazzoni"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/ZVaRK10HBjo/maxresdefault.jpg",
   "title": "Introduction to Docker and containers",
   "videos": [
     {
-      "length": 11354,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=ZVaRK10HBjo"
     }

--- a/pycon-us-2016/videos/josh-triplett-networking-without-an-os-pycon-2016.json
+++ b/pycon-us-2016/videos/josh-triplett-networking-without-an-os-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Josh Triplett\n\nMany Python modules, such as socket and select, wrap low-level functionality written in C and provided by the OS. But what if you don't have an OS, and don't want any C code? We implemented client and server networking in Python itself, for a bare-metal environment running without an OS.\n\nOur socket and select implementations support Python HTTP server and client modules, which we'll demo live.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1890,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "josh-triplett-networking-without-an-os-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Josh Triplett"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/AlkKvetGFSk/maxresdefault.jpg",
   "title": "Networking without an OS",
   "videos": [
     {
-      "length": 1890,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=AlkKvetGFSk"
     }

--- a/pycon-us-2016/videos/julia-ferraioli-amy-unruh-eli-bixby-diving-into-machine-learning-through-tensorflow-pycon-2016.json
+++ b/pycon-us-2016/videos/julia-ferraioli-amy-unruh-eli-bixby-diving-into-machine-learning-through-tensorflow-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speakers: Julia Ferraioli, Amy Unruh, Eli Bixby\n\nMachine learning can be an intimidating subject. In this session, we\u2019ll get practical, hands-on experience with core concepts in machine learning with TensorFlow, an open source deep learning library. We\u2019ll introduce the basics of TensorFlow, including how to ingest and prepare raw data for use, run a variety of algorithms to gain insight from the data, and have some fun with visualization.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 10506,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-29",
   "related_urls": [],
   "slug": "julia-ferraioli-amy-unruh-eli-bixby-diving-into-machine-learning-through-tensorflow-pycon-2016",
@@ -13,14 +12,11 @@
     "Amy Unruh",
     "Eli Bixby"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/GZBIPwdGtkk/maxresdefault.jpg",
   "title": "Diving into Machine Learning through TensorFlow",
   "videos": [
     {
-      "length": 10506,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=GZBIPwdGtkk"
     }

--- a/pycon-us-2016/videos/juozas-kaziukenas-building-an-interpreter-in-rpython-pycon-2016.json
+++ b/pycon-us-2016/videos/juozas-kaziukenas-building-an-interpreter-in-rpython-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Juozas Kaziuk\u0117nas\n\nTo understand how dynamic programming languages get executed I set out to build a PHP interpreter. Not a joke, I really did it and it worked! The final result was a well-tested piece of Python code, which could be compiled to be very performant as well.\n\nThe goal of this talk is to introduce you to the basics of interpreters and the tools available in RPython to build one.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2584,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "juozas-kaziukenas-building-an-interpreter-in-rpython-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Juozas Kaziuk\u0117nas"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/9tDpjzPLvNY/maxresdefault.jpg",
   "title": "Building An Interpreter In RPython",
   "videos": [
     {
-      "length": 2584,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=9tDpjzPLvNY"
     }

--- a/pycon-us-2016/videos/k-lars-lohn-keynote-pycon-2016.json
+++ b/pycon-us-2016/videos/k-lars-lohn-keynote-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: K Lars Lohn\n\nKeynote\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 3125,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "k-lars-lohn-keynote-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "K Lars Lohn"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/bSfe5M_zG2s/maxresdefault.jpg",
   "title": "Keynote",
   "videos": [
     {
-      "length": 3125,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=bSfe5M_zG2s"
     }

--- a/pycon-us-2016/videos/karen-rubin-building-a-quantitative-trading-strategy-to-beat-the-sp500-pycon-2016.json
+++ b/pycon-us-2016/videos/karen-rubin-building-a-quantitative-trading-strategy-to-beat-the-sp500-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Karen Rubin\n\nTwo years ago, Karen embarked on a project to learn how to research, write and trade algorithms to invest in the market. She re-learned python and explored what would happen if you invested in women-led companies over a 12-year period. In this talk, she will walk through the highs and lows of her journey from initial data gathering, through writing a strategy to validation and trading.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2789,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "karen-rubin-building-a-quantitative-trading-strategy-to-beat-the-sp500-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Karen Rubin"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/ll6Tq-wTXXw/maxresdefault.jpg",
   "title": "Building a Quantitative Trading Strategy To Beat the S&P500",
   "videos": [
     {
-      "length": 2789,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=ll6Tq-wTXXw"
     }

--- a/pycon-us-2016/videos/kate-heddleston-joyce-jang-usable-ops-how-to-make-web-infrastructure-management-easier.json
+++ b/pycon-us-2016/videos/kate-heddleston-joyce-jang-usable-ops-how-to-make-web-infrastructure-management-easier.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speakers: Kate Heddleston, Joyce Jang\n\nAs developer tools increase in power, the systems we\u2019re able to build do too. However, with great power comes great...complexity, and the systems we build today are more complex than ever before. This talk is about reducing the complexity of your web infrastructure, and making it easier for developers on your team to learn, use, and manage your infrastructure.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2467,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "kate-heddleston-joyce-jang-usable-ops-how-to-make-web-infrastructure-management-easier",
@@ -12,14 +11,11 @@
     "Kate Heddleston",
     "Joyce Jang"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/4pFs5ZquZcc/maxresdefault.jpg",
   "title": "Usable Ops: How to make web infrastructure management easier.",
   "videos": [
     {
-      "length": 2467,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=4pFs5ZquZcc"
     }

--- a/pycon-us-2016/videos/katie-bell-the-computer-science-of-marking-computer-science-assignments-pycon-2016.json
+++ b/pycon-us-2016/videos/katie-bell-the-computer-science-of-marking-computer-science-assignments-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Katie Bell\n\nWhen writing systems to test if beginner programmers' code was correct, I didn't expect to need numpy, scipy a custom C module and a whole lot of cool geometry algorithms. Giving actionable feedback on tasks (in this case logo/turtle vector drawings), is necessary for the learning process and goes some fun places. Take this as a case study of writing efficient geometry number crunching in Python.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1462,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "katie-bell-the-computer-science-of-marking-computer-science-assignments-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Katie Bell"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/-qpHnJh6iB4/maxresdefault.jpg",
   "title": "The computer science of marking computer science assignments",
   "videos": [
     {
-      "length": 1462,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=-qpHnJh6iB4"
     }

--- a/pycon-us-2016/videos/katie-mclaughlin-build-a-better-hat-rack-all-contributions-welcome-pycon-2016.json
+++ b/pycon-us-2016/videos/katie-mclaughlin-build-a-better-hat-rack-all-contributions-welcome-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Katie McLaughlin\n\nBy default, we idolise a 'open source contributor' as a person that contributes code. But what about all the other things in the software development lifecycle - documentation, code review, marketing, support - so much work happens without proper acknowledgement. Learn just how every little bit helps, and how to find and acknowledge these contributions.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1487,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "katie-mclaughlin-build-a-better-hat-rack-all-contributions-welcome-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Katie McLaughlin"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/iAu7Xw9lFt0/maxresdefault.jpg",
   "title": "Build a Better Hat Rack: All Contributions Welcome",
   "videos": [
     {
-      "length": 1487,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=iAu7Xw9lFt0"
     }

--- a/pycon-us-2016/videos/kavya-joshi-a-tale-of-concurrency-through-creativity-in-python-a-deep-dive-into-how-gevent-works.json
+++ b/pycon-us-2016/videos/kavya-joshi-a-tale-of-concurrency-through-creativity-in-python-a-deep-dive-into-how-gevent-works.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Kavya Joshi\n\ngevent is an open source Python library for asynchronous I/O. It provides a powerful construct to build concurrent applications; think threads, except lightweight and cooperatively scheduled. We will delve into how gevent is architected from its building blocks \u2014 sophisticated coroutines, an event loop, and a dash of creativity to neatly integrate them.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1809,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "kavya-joshi-a-tale-of-concurrency-through-creativity-in-python-a-deep-dive-into-how-gevent-works",
@@ -11,14 +10,11 @@
   "speakers": [
     "Kavya Joshi"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/GunMToxbE0E/maxresdefault.jpg",
   "title": "A tale of concurrency through creativity in Python: a deep dive into how gevent works.",
   "videos": [
     {
-      "length": 1809,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=GunMToxbE0E"
     }

--- a/pycon-us-2016/videos/kelsey-gilmore-innis-seriously-strong-security-on-a-shoestring-cw-pycon-2016.json
+++ b/pycon-us-2016/videos/kelsey-gilmore-innis-seriously-strong-security-on-a-shoestring-cw-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Kelsey Gilmore-Innis\n\nAre you confident your Python webapp is secure? Really confident? Hand-it-over-to-a-team-of-expert-haxx0rs\u00ad-to-tear-into confident? Find out how, without any formal security background, we successfully built a site storing some of the most sensitive data imaginable that passed a formal security audit from the best in the business. Content warning: this talk includes discussion of sexual assault.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1580,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "kelsey-gilmore-innis-seriously-strong-security-on-a-shoestring-cw-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Kelsey Gilmore-Innis"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/8FeNdXzVLEs/maxresdefault.jpg",
   "title": "Seriously Strong Security on a Shoestring (CW)",
   "videos": [
     {
-      "length": 1580,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=8FeNdXzVLEs"
     }

--- a/pycon-us-2016/videos/kenneth-love-django-101-pycon-2016.json
+++ b/pycon-us-2016/videos/kenneth-love-django-101-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Kenneth Love\n\nWant to build web apps with Django but don't know where to start? Did the Django tutorial but still feel unsure? Django 101 is a gentle introduction to Django. By the end, you'll be more confident in starting projects, apps, and tying together the most common pieces of Django.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 7472,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-29",
   "related_urls": [],
   "slug": "kenneth-love-django-101-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Kenneth Love"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/C0wuTkS93B0/maxresdefault.jpg",
   "title": "Django 101",
   "videos": [
     {
-      "length": 7472,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=C0wuTkS93B0"
     }

--- a/pycon-us-2016/videos/kevin-markham-machine-learning-with-text-in-scikit-learn-pycon-2016.json
+++ b/pycon-us-2016/videos/kevin-markham-machine-learning-with-text-in-scikit-learn-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Kevin Markham\n\nAlthough numeric data is easy to work with in Python, most knowledge created by humans is actually raw, unstructured text. By learning how to transform text into data that is usable by machine learning models, you drastically increase the amount of data that your models can learn from. In this tutorial, we'll build and evaluate predictive models from real-world text using scikit-learn.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 9872,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-09",
   "related_urls": [],
   "slug": "kevin-markham-machine-learning-with-text-in-scikit-learn-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Kevin Markham"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/WHocRqT-KkU/maxresdefault.jpg",
   "title": "Machine Learning with Text in scikit-learn",
   "videos": [
     {
-      "length": 9872,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=WHocRqT-KkU"
     }

--- a/pycon-us-2016/videos/larry-hastings-removing-pythons-gil-the-gilectomy-pycon-2016.json
+++ b/pycon-us-2016/videos/larry-hastings-removing-pythons-gil-the-gilectomy-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Larry Hastings\n\nYou've heard of Python's \"\"GIL\"\"... but what is it?  What problems does it solve?  How does it work?  What are the ramifications of its design?   Attendees should have a basic knowledge of multithreaded programming.  Understanding C is helpful but not required.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1927,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "larry-hastings-removing-pythons-gil-the-gilectomy-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Larry Hastings"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/P3AyI_u66Bw/maxresdefault.jpg",
   "title": "Removing Python's GIL: The Gilectomy",
   "videos": [
     {
-      "length": 1927,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=P3AyI_u66Bw"
     }

--- a/pycon-us-2016/videos/laura-rupprecht-what-can-software-engineers-learn-from-the-medical-field-pycon-2016.json
+++ b/pycon-us-2016/videos/laura-rupprecht-what-can-software-engineers-learn-from-the-medical-field-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Laura Rupprecht\n\nThere is a long history of improvements to medical practices, many of which can be applied to software development. This talk will explore some of those practices, and how they can be translated to the world of software.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1532,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "laura-rupprecht-what-can-software-engineers-learn-from-the-medical-field-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Laura Rupprecht"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/IcMupSYqRa4/maxresdefault.jpg",
   "title": "What can software engineers learn from the medical field?",
   "videos": [
     {
-      "length": 1532,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=IcMupSYqRa4"
     }

--- a/pycon-us-2016/videos/lightning-talks-2016-05-30.json
+++ b/pycon-us-2016/videos/lightning-talks-2016-05-30.json
@@ -1,22 +1,18 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "",
   "duration": 3284,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "lightning-talks-2016-05-30",
   "source_url": "https://www.youtube.com/watch?v=yC9m2GInXqU",
   "speakers": [],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/yC9m2GInXqU/maxresdefault.jpg",
   "title": "Lightning Talks - 2016-05-30",
   "videos": [
     {
-      "length": 3284,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=yC9m2GInXqU"
     }

--- a/pycon-us-2016/videos/lightning-talks-2016-05-31-am.json
+++ b/pycon-us-2016/videos/lightning-talks-2016-05-31-am.json
@@ -1,22 +1,18 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "",
   "duration": 1884,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "lightning-talks-2016-05-31-am",
   "source_url": "https://www.youtube.com/watch?v=7pIn2TCw2Us",
   "speakers": [],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/7pIn2TCw2Us/hqdefault.jpg",
   "title": "Lightning Talks - 2016-05-31 AM",
   "videos": [
     {
-      "length": 1884,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=7pIn2TCw2Us"
     }

--- a/pycon-us-2016/videos/lightning-talks-2016-05-31pm.json
+++ b/pycon-us-2016/videos/lightning-talks-2016-05-31pm.json
@@ -1,22 +1,18 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "",
   "duration": 3906,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "lightning-talks-2016-05-31pm",
   "source_url": "https://www.youtube.com/watch?v=PulzIT8KYLk",
   "speakers": [],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/PulzIT8KYLk/maxresdefault.jpg",
   "title": "Lightning Talks - 2016-05-31PM",
   "videos": [
     {
-      "length": 3906,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=PulzIT8KYLk"
     }

--- a/pycon-us-2016/videos/lightning-talks-2016-06-01.json
+++ b/pycon-us-2016/videos/lightning-talks-2016-06-01.json
@@ -1,22 +1,18 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "",
   "duration": 1806,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "lightning-talks-2016-06-01",
   "source_url": "https://www.youtube.com/watch?v=ntPsUFSeYsw",
   "speakers": [],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/ntPsUFSeYsw/maxresdefault.jpg",
   "title": "Lightning Talks - 2016-06-01",
   "videos": [
     {
-      "length": 1806,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=ntPsUFSeYsw"
     }

--- a/pycon-us-2016/videos/lorena-barba-keynote-pycon-2016.json
+++ b/pycon-us-2016/videos/lorena-barba-keynote-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Lorena Barba\n\nKeynote\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 4329,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "lorena-barba-keynote-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Lorena Barba"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/ckW1xuGVpug/maxresdefault.jpg",
   "title": "Keynote",
   "videos": [
     {
-      "length": 4329,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=ckW1xuGVpug"
     }

--- a/pycon-us-2016/videos/luciano-ramalho-pythonic-objects-implementing-productive-apis-with-the-python-data-model.json
+++ b/pycon-us-2016/videos/luciano-ramalho-pythonic-objects-implementing-productive-apis-with-the-python-data-model.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Luciano Ramalho\n\nPython is so consistent that often we can infer the behavior of new objects by assuming they work as the built-ins. The Python Data Model is the foundation of this consistent behavior. This talk presents the construction of Pythonic objects: classes that feel \"\"natural\"\" to a Python programmer, and leverage some of the best language features by implementing key protocols of the Data Model.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 10913,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-29",
   "related_urls": [],
   "slug": "luciano-ramalho-pythonic-objects-implementing-productive-apis-with-the-python-data-model",
@@ -11,14 +10,11 @@
   "speakers": [
     "Luciano Ramalho"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/k55d3ZUF3ZQ/maxresdefault.jpg",
   "title": "Pythonic Objects: implementing productive APIs with the Python Data Model",
   "videos": [
     {
-      "length": 10913,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=k55d3ZUF3ZQ"
     }

--- a/pycon-us-2016/videos/luke-sneeringer-ansible-101-pycon-2016.json
+++ b/pycon-us-2016/videos/luke-sneeringer-ansible-101-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Luke Sneeringer\n\nAnsible has become one of the most popular tools available for deploying applications and otherwise managing large numbers of servers. Its agentless nature means that the only thing you need on a server to be able to orchestrate it is SSH. This tutorial will get you started with Ansible, first by covering the concepts, and then by deploying a non-trivial application together.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 11000,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-29",
   "related_urls": [],
   "slug": "luke-sneeringer-ansible-101-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Luke Sneeringer"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/smVDugAW4G4/maxresdefault.jpg",
   "title": "Ansible 101",
   "videos": [
     {
-      "length": 11000,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=smVDugAW4G4"
     }

--- a/pycon-us-2016/videos/lvh-cory-benfield-glyph-hynek-schlawack-paul-kehrer-the-hitchhikers-guide-to-tls-ssl.json
+++ b/pycon-us-2016/videos/lvh-cory-benfield-glyph-hynek-schlawack-paul-kehrer-the-hitchhikers-guide-to-tls-ssl.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speakers: lvh, Cory Benfield, Glyph, Hynek Schlawack, Paul Kehrer\n\nSince the SSL/TLS vulnerabilities in recent years, the landscape has improved considerably.  However, there\u2019s still a lot of knowledge necessary to use TLS in Python properly, and a lot of useful information for setting up and debugging TLS stacks that\u2019s hard to come by.  Join the makers of PyOpenSSL, the standard library\u2019s ssl module, requests/urllib3, Twisted, the former maintainer of a CA, and\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 10469,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-29",
   "related_urls": [],
   "slug": "lvh-cory-benfield-glyph-hynek-schlawack-paul-kehrer-the-hitchhikers-guide-to-tls-ssl",
@@ -15,14 +14,11 @@
     "Hynek Schlawack",
     "Paul Kehrer"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/JHF1PDZsx0c/maxresdefault.jpg",
   "title": "The Hitchhiker's Guide to TLS & SSL",
   "videos": [
     {
-      "length": 10469,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=JHF1PDZsx0c"
     }

--- a/pycon-us-2016/videos/lynn-root-noa-resare-why-cant-we-be-friends-do-corporations-and-foss-really-mix-pycon-2016.json
+++ b/pycon-us-2016/videos/lynn-root-noa-resare-why-cant-we-be-friends-do-corporations-and-foss-really-mix-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speakers: Lynn Root, Noa Resare\n\nMany folks in the Python community appreciate and contribute to Free and Open Source Software. But sometimes, your employer may not be on your side. We will present the current problem space that both community members and companies have for using and supporting FOSS. We will then walk you through arguments and solutions to help increase your company's engagement with the community.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1886,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "lynn-root-noa-resare-why-cant-we-be-friends-do-corporations-and-foss-really-mix-pycon-2016",
@@ -12,14 +11,11 @@
     "Lynn Root",
     "Noa Resare"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/UV3-w0gvrrU/maxresdefault.jpg",
   "title": "Why can't we be friends: do corporations and FOSS really mix?",
   "videos": [
     {
-      "length": 1886,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=UV3-w0gvrrU"
     }

--- a/pycon-us-2016/videos/making-an-impact-with-python-natural-language-processing-tools-pycon-2016.json
+++ b/pycon-us-2016/videos/making-an-impact-with-python-natural-language-processing-tools-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speakers: Hobson Lane, Dan Fellin, Jeremy Robin\n\nDo your tweets get lost in the shuffle? Would you like to predict a tweet's impact before you hit send? Python now has all the tools to make this possible. Several Python packages for machine learning and natural language processing have reached \"\"critical mass\"\" and can now be combined to perform these and other powerful natural language processing tasks. This tutorial will teach you how.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 10475,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-09",
   "related_urls": [],
   "slug": "making-an-impact-with-python-natural-language-processing-tools-pycon-2016",
@@ -13,14 +12,11 @@
     "Dan Fellin",
     "Jeremy Robin"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/jSdkFSg9oW8/maxresdefault.jpg",
   "title": "Making an Impact with Python Natural Language Processing Tools",
   "videos": [
     {
-      "length": 10475,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=jSdkFSg9oW8"
     }

--- a/pycon-us-2016/videos/manuel-ebert-putting-1-million-new-words-into-the-dictionary-pycon-2016.json
+++ b/pycon-us-2016/videos/manuel-ebert-putting-1-million-new-words-into-the-dictionary-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Manuel Ebert\n\n2015 was the year of spocking, amabots, dadbuds, and smol. Like half of all english words used every day, these words are not in the dictionary. Until we put them there. In this talk, I\u2019ll describe how we found definitions for 1 Million words that were missing from dictionaries, what it takes to do Natural Language Processing at that scale, and how to be the least popular scrabble winner.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2533,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "manuel-ebert-putting-1-million-new-words-into-the-dictionary-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Manuel Ebert"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/sum5Hq2FTsw/maxresdefault.jpg",
   "title": "Putting 1 million new words into the dictionary",
   "videos": [
     {
-      "length": 2533,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=sum5Hq2FTsw"
     }

--- a/pycon-us-2016/videos/marko-samastur-publish-your-code-so-others-can-use-it-in-5-easy-steps-pycon-2016.json
+++ b/pycon-us-2016/videos/marko-samastur-publish-your-code-so-others-can-use-it-in-5-easy-steps-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Marko Samastur\n\nAs developers we all love well-documented, well-tested packages. If we do the same for our code it is easier for others to re-use our hard work, and maybe even contribute. We will take a quick look on how to do this using popular tools and only a small investment of time. With Github and some simple tools, setting up a well-groomed package doesn't have to be difficult.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1955,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-17",
   "related_urls": [],
   "slug": "marko-samastur-publish-your-code-so-others-can-use-it-in-5-easy-steps-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Marko Samastur"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/nFozViwDWvY/maxresdefault.jpg",
   "title": "Publish your code so others can use it in 5 easy steps",
   "videos": [
     {
-      "length": 1955,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=nFozViwDWvY"
     }

--- a/pycon-us-2016/videos/matt-bachmann-better-testing-with-less-code-property-based-testing-with-python-pycon-2016.json
+++ b/pycon-us-2016/videos/matt-bachmann-better-testing-with-less-code-property-based-testing-with-python-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Matt Bachmann\n\nStandard unit tests have developers test specific inputs and outputs. This works, but often what breaks code are the cases we did not think about. Property based testing has developers define properties of output and has the computer explore the possible inputs to verify these properties. This talk will introduce property based testing and provide real world examples and patterns.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1648,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "matt-bachmann-better-testing-with-less-code-property-based-testing-with-python-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Matt Bachmann"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/jvwfDdgg93E/maxresdefault.jpg",
   "title": "Better Testing With Less Code: Property Based Testing With Python",
   "videos": [
     {
-      "length": 1648,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=jvwfDdgg93E"
     }

--- a/pycon-us-2016/videos/matthias-kramm-python-typology-pycon-2016.json
+++ b/pycon-us-2016/videos/matthias-kramm-python-typology-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Matthias Kramm\n\nWith PEP 484, Python now has a standard for adding type declarations to your programs. What checks these declarations, and how? I present one of the options, pytype, which Google has been working on for the last two years.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1906,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "matthias-kramm-python-typology-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Matthias Kramm"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/IDm_YIQihhs/maxresdefault.jpg",
   "title": "Python Typology",
   "videos": [
     {
-      "length": 1906,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=IDm_YIQihhs"
     }

--- a/pycon-us-2016/videos/melinda-shore-advanced-dns-services-for-securing-your-application-and-enhancing-user-privacymp4.json
+++ b/pycon-us-2016/videos/melinda-shore-advanced-dns-services-for-securing-your-application-and-enhancing-user-privacymp4.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Melinda Shore\n\nThis talk introduces new features that have been added to the Domain Name System recently, and how to use those features to improve application security and user privacy. I also introduce the \"getdns\" Python library, which provides a simplified DNS API, and how to interface with popular crypto libraries.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1820,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-17",
   "related_urls": [],
   "slug": "melinda-shore-advanced-dns-services-for-securing-your-application-and-enhancing-user-privacymp4",
@@ -11,14 +10,11 @@
   "speakers": [
     "Melinda Shore"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/-BtIQ3brsIY/maxresdefault.jpg",
   "title": "Advanced DNS Services for Securing Your Application and Enhancing User Privacy",
   "videos": [
     {
-      "length": 1820,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=-BtIQ3brsIY"
     }

--- a/pycon-us-2016/videos/mercedes-coyle-build-serverless-realtime-data-pipelines-with-python-and-aws-lambda-pycon-2016.json
+++ b/pycon-us-2016/videos/mercedes-coyle-build-serverless-realtime-data-pipelines-with-python-and-aws-lambda-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Mercedes Coyle\n\nAt Scripps Networks Living, we operate a network of video players generating around 100 million events per day. In order to process, store, and analyze this data, we operate batch and realtime data pipelines based off of Lambda Architecture principles. After outgrowing our original events system, we rebuilt it from the ground up based on AWS Services and the learnings from our original system.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1695,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "mercedes-coyle-build-serverless-realtime-data-pipelines-with-python-and-aws-lambda-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Mercedes Coyle"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/EpCHD9AIHAM/maxresdefault.jpg",
   "title": "Build Serverless Realtime Data Pipelines with Python and AWS Lambda",
   "videos": [
     {
-      "length": 1695,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=EpCHD9AIHAM"
     }

--- a/pycon-us-2016/videos/michael-tom-wing-christie-wilson-introduction-to-unit-testing-in-python-with-pytest-pycon-2016.json
+++ b/pycon-us-2016/videos/michael-tom-wing-christie-wilson-introduction-to-unit-testing-in-python-with-pytest-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speakers: Michael Tom-Wing, Christie Wilson\n\nIn this tutorial we\u2019ll be taking you on a journey into the wonderful land of unit testing with pytest. We\u2019ll be taking a step by step approach by iteratively adding unit test coverage to our awesome Cat In A Box\u2122 project. You will also get a crash course on Git, Github, virtualenvs, and test automation. By the end, we hope that you\u2019ll have a desire to bring testing to our own projects!\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 9106,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "michael-tom-wing-christie-wilson-introduction-to-unit-testing-in-python-with-pytest-pycon-2016",
@@ -12,14 +11,11 @@
     "Michael Tom-Wing",
     "Christie Wilson"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/UPanUFVFfzY/maxresdefault.jpg",
   "title": "Introduction to Unit Testing in Python with Pytest",
   "videos": [
     {
-      "length": 9106,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=UPanUFVFfzY"
     }

--- a/pycon-us-2016/videos/miguel-grinberg-flask-at-scale-pycon-2016.json
+++ b/pycon-us-2016/videos/miguel-grinberg-flask-at-scale-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Miguel Grinberg\n\nDo you think that because Flask is a micro-framework, it must only be good for small, toy-like web applications? Well, not at all! In this tutorial I am going to show you a few patterns and best practices that can take your Flask application to the next level.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 11100,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-29",
   "related_urls": [],
   "slug": "miguel-grinberg-flask-at-scale-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Miguel Grinberg"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/tdIIJuPh3SI/maxresdefault.jpg",
   "title": "Flask at Scale",
   "videos": [
     {
-      "length": 11100,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=tdIIJuPh3SI"
     }

--- a/pycon-us-2016/videos/mike-graham-the-life-cycle-of-a-python-class-pycon-2016.json
+++ b/pycon-us-2016/videos/mike-graham-the-life-cycle-of-a-python-class-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Mike Graham\n\nAnd end-to-end look at the life and death of a class and its instance.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2244,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "mike-graham-the-life-cycle-of-a-python-class-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Mike Graham"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/kZtC_4Ecq1Y/maxresdefault.jpg",
   "title": "The Life Cycle of a Python Class",
   "videos": [
     {
-      "length": 2244,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=kZtC_4Ecq1Y"
     }

--- a/pycon-us-2016/videos/mike-mckerns-efficient-python-for-high-performance-parallel-computing-pycon-2016.json
+++ b/pycon-us-2016/videos/mike-mckerns-efficient-python-for-high-performance-parallel-computing-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Mike McKerns\n\nThis tutorial is targeted at the intermediate-to-advanced Python user who wants to extend Python into High-Performance Computing. The tutorial will provide hands-on examples and essential performance tips every developer should know for writing effective parallel Python. The result will be a clear sense of possibilities and best practices using Python in HPC environments.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 11345,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "mike-mckerns-efficient-python-for-high-performance-parallel-computing-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Mike McKerns"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/6zQhUlMYea4/maxresdefault.jpg",
   "title": "Efficient Python for High-Performance Parallel Computing",
   "videos": [
     {
-      "length": 11345,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=6zQhUlMYea4"
     }

--- a/pycon-us-2016/videos/mike-muller-descriptors-and-metaclasses-understanding-and-using-pythons-more-advanced-features.json
+++ b/pycon-us-2016/videos/mike-muller-descriptors-and-metaclasses-understanding-and-using-pythons-more-advanced-features.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Mike M\u00fcller\n\nDescriptors and metaclasses are advanced Python features. While it is\npossible to write Python programs without active knowledge of them,\nknowing more about them facilitates a deeper understanding of\nthe language. With examples, you will learn how they work and how to\nwrite your own descriptors and metaclasses. Furthermore, you will understand\nwhen to use and when better not to use them.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 10922,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "mike-muller-descriptors-and-metaclasses-understanding-and-using-pythons-more-advanced-features",
@@ -11,14 +10,11 @@
   "speakers": [
     "Mike M\u00fcller"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/7PzeZQGVPKc/maxresdefault.jpg",
   "title": "Descriptors and Metaclasses - Understanding and Using Python's More Advanced Features",
   "videos": [
     {
-      "length": 10922,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=7PzeZQGVPKc"
     }

--- a/pycon-us-2016/videos/mike-muller-faster-python-programs-measure-dont-guess-pycon-2016.json
+++ b/pycon-us-2016/videos/mike-muller-faster-python-programs-measure-dont-guess-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Mike M\u00fcller\n\nOptimization can often help to make Python programs faster or use less memory.\nDeveloping a strategy, establishing solid measuring and visualization techniques\nas well as knowing about algorithmic basics and datastructures are the foundation\nfor a successful optimization. The tutorial will cover these topics.\nExamples will give you a hands-on experience on how to approach efficiently.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 11037,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "mike-muller-faster-python-programs-measure-dont-guess-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Mike M\u00fcller"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/JDSGVvMwNM8/maxresdefault.jpg",
   "title": "Faster Python Programs - Measure, don't Guess",
   "videos": [
     {
-      "length": 11037,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=JDSGVvMwNM8"
     }

--- a/pycon-us-2016/videos/mike-pirnat-david-stanek-shiny-lets-be-bad-guys.json
+++ b/pycon-us-2016/videos/mike-pirnat-david-stanek-shiny-lets-be-bad-guys.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speakers: Mike Pirnat, David Stanek\n\nThe Internet is a dangerous place, filled with evildoers out to attack your code for fun or profit, so it's not enough to just ship your awesome new web app--you have to take the security of your application, your users, and your data seriously. You'll get into the mindset of the bad guys as we discuss, exploit, and mitigate the most common web\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 10305,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-29",
   "related_urls": [],
   "slug": "mike-pirnat-david-stanek-shiny-lets-be-bad-guys",
@@ -12,14 +11,11 @@
     "Mike Pirnat",
     "David Stanek"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/8poZXUcwBgs/maxresdefault.jpg",
   "title": "SHINY, LET'S BE BAD GUYS",
   "videos": [
     {
-      "length": 10305,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=8poZXUcwBgs"
     }

--- a/pycon-us-2016/videos/naomi-ceder-antipatterns-for-diversity-pycon-2016.json
+++ b/pycon-us-2016/videos/naomi-ceder-antipatterns-for-diversity-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Naomi Ceder\n\nJust as there is no single easy way to write good code there is no single easy way to increase diversity. There are, however, several things we (yes, even in the Python community) do which actually work against diversity. This talk will explore these anti-patterns for diversity,  as well as some ways that teams, companies, and organizations might work to combat them.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1468,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "naomi-ceder-antipatterns-for-diversity-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Naomi Ceder"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/Xg1LgSg3pmo/maxresdefault.jpg",
   "title": "Antipatterns for Diversity",
   "videos": [
     {
-      "length": 1468,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=Xg1LgSg3pmo"
     }

--- a/pycon-us-2016/videos/nathaniel-manista-augie-fackler-code-unto-others-pycon-2016.json
+++ b/pycon-us-2016/videos/nathaniel-manista-augie-fackler-code-unto-others-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speakers: Nathaniel Manista, Augie Fackler\n\nLarge codebases written by many authors over long periods of time too often become tragedies of the commons riddled with complexity and technical debt. We\u2019ll cover the pathologies that specifically encumber collaborative software development (drawing on examples from the Mercurial codebase) and describe alternative practices, their efficacy, and the costs of adopting them.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1892,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-09",
   "related_urls": [],
   "slug": "nathaniel-manista-augie-fackler-code-unto-others-pycon-2016",
@@ -12,14 +11,11 @@
     "Nathaniel Manista",
     "Augie Fackler"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/aOEfIrC07XA/maxresdefault.jpg",
   "title": "Code Unto Others",
   "videos": [
     {
-      "length": 1892,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=aOEfIrC07XA"
     }

--- a/pycon-us-2016/videos/ned-batchelder-machete-mode-debugging-hacking-your-way-out-of-a-tight-spot-pycon-2016.json
+++ b/pycon-us-2016/videos/ned-batchelder-machete-mode-debugging-hacking-your-way-out-of-a-tight-spot-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Ned Batchelder\n\nWhen chasing mysterious bugs, it's helpful to use all the tools at your disposal.  We'll explore ways to use Python's dynamic tools to help track down the cause of head-scratching problems in large systems.  Tools include the inspect module, monkey-patching, trace functions, and the Python mechanisms at work behind them all.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2113,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-09",
   "related_urls": [],
   "slug": "ned-batchelder-machete-mode-debugging-hacking-your-way-out-of-a-tight-spot-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Ned Batchelder"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/bAcfPzxB3dk/maxresdefault.jpg",
   "title": "Machete-mode debugging: Hacking your way out of a tight spot",
   "videos": [
     {
-      "length": 2113,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=bAcfPzxB3dk"
     }

--- a/pycon-us-2016/videos/nicholas-tollervey-education-summit-wrap-up-teaching-python-how-hard-can-it-be-pycon-2016.json
+++ b/pycon-us-2016/videos/nicholas-tollervey-education-summit-wrap-up-teaching-python-how-hard-can-it-be-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Nicholas Tollervey\n\nIf you teach, if you Python \u2014 join us for a whirlwind tour of this year's Python Education Summit.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1565,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "nicholas-tollervey-education-summit-wrap-up-teaching-python-how-hard-can-it-be-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Nicholas Tollervey"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/33aSGoPhh7c/maxresdefault.jpg",
   "title": "Education Summit wrap-up: teaching Python \u2014 how hard can it be?",
   "videos": [
     {
-      "length": 1565,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=33aSGoPhh7c"
     }

--- a/pycon-us-2016/videos/nina-zakharenko-memory-management-in-python-the-basics-pycon-2016.json
+++ b/pycon-us-2016/videos/nina-zakharenko-memory-management-in-python-the-basics-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Nina Zakharenko\n\nAs a new python developer, do you find memory management in Python confusing? Come to this talk to learn about the basics of how Memory Management works in Python. We'll cover the concepts of reference counting, garbage collection, weak references, __slots__, and the Global Interpreter Lock.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1620,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "nina-zakharenko-memory-management-in-python-the-basics-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Nina Zakharenko"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/F6u5rhUQ6dU/maxresdefault.jpg",
   "title": "Memory Management in Python - The Basics",
   "videos": [
     {
-      "length": 1620,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=F6u5rhUQ6dU"
     }

--- a/pycon-us-2016/videos/parisa-tabriz-keynote-pycon-2016.json
+++ b/pycon-us-2016/videos/parisa-tabriz-keynote-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Parisa Tabriz\n\nKeynote\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2268,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "parisa-tabriz-keynote-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Parisa Tabriz"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/kxqci2mZdrc/maxresdefault.jpg",
   "title": "Keynote",
   "videos": [
     {
-      "length": 2268,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=kxqci2mZdrc"
     }

--- a/pycon-us-2016/videos/partial-harry-percival-python-bootcamp-pycon-2016.json
+++ b/pycon-us-2016/videos/partial-harry-percival-python-bootcamp-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Harry Percival\n\nIf you\u2019re thinking of coming to the conference but you\u2019re new to Python, this could be the session for you. Whether you\u2019re totally new to programming or you already know another language, this hands-on session will give you a crash-course in Python, and the ecosystem around it, to give you the context you need to get the most out of the rest of Pycon.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2986,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-29",
   "related_urls": [],
   "slug": "partial-harry-percival-python-bootcamp-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Harry Percival"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/YNZLm-dX6HM/maxresdefault.jpg",
   "title": "(PARTIAL) - Python Bootcamp",
   "videos": [
     {
-      "length": 2986,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=YNZLm-dX6HM"
     }

--- a/pycon-us-2016/videos/paul-kehrer-reliably-distributing-compiled-modules-pycon-2016.json
+++ b/pycon-us-2016/videos/paul-kehrer-reliably-distributing-compiled-modules-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Paul Kehrer\n\nShipping Python libraries is easy! ...until you want to use a C library. How do you easily and reliably deliver software to users when they may not have the libraries you depend on, or even a compiler? How do you handle the significant differences between linux, OS X, Windows, FreeBSD, and other platforms Python runs on?\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1843,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "paul-kehrer-reliably-distributing-compiled-modules-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Paul Kehrer"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/-j4lolWgD6Q/maxresdefault.jpg",
   "title": "Reliably Distributing Compiled Modules",
   "videos": [
     {
-      "length": 1843,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=-j4lolWgD6Q"
     }

--- a/pycon-us-2016/videos/paul-ross-here-be-dragons-writing-safe-c-extensions-pycon-2016.json
+++ b/pycon-us-2016/videos/paul-ross-here-be-dragons-writing-safe-c-extensions-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Paul Ross\n\nWriting Python Extensions can be daunting. This talk de-mystifies what you need to know to write reliable and blazingly fast Pythonic C code.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1714,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "paul-ross-here-be-dragons-writing-safe-c-extensions-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Paul Ross"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/Yq__HtUIH5Y/maxresdefault.jpg",
   "title": "Here be Dragons - Writing Safe C Extensions",
   "videos": [
     {
-      "length": 1714,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=Yq__HtUIH5Y"
     }

--- a/pycon-us-2016/videos/paulus-schoutsen-awaken-your-home-python-and-the-internet-of-things-pycon-2016.json
+++ b/pycon-us-2016/videos/paulus-schoutsen-awaken-your-home-python-and-the-internet-of-things-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Paulus Schoutsen\n\nPeople are acquiring more and more connected devices for their homes. With no standard in place for communication, vendors are shipping their own platforms. This results in devices unable to work together. This talk shows people how to take control of their houses, their data and their privacy using Python \u2013 no cloud attached. Enter the world of Home Assistant.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1826,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-16",
   "related_urls": [],
   "slug": "paulus-schoutsen-awaken-your-home-python-and-the-internet-of-things-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Paulus Schoutsen"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/Cfasc9EgbMU/hqdefault.jpg",
   "title": "Awaken your home: Python and the Internet of Things",
   "videos": [
     {
-      "length": 1826,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=Cfasc9EgbMU"
     }

--- a/pycon-us-2016/videos/pramod-gupta-computational-physics-with-python-planetary-orbits-from-newton-to-feynman.json
+++ b/pycon-us-2016/videos/pramod-gupta-computational-physics-with-python-planetary-orbits-from-newton-to-feynman.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Pramod Gupta\n\nNewton's explanation of planetary orbits is one of the greatest achievements of science. We will follow Feynman's approach to show how the motion of the planets around the sun can be calculated using computers and without using Newton's advanced mathematics. This talk will convince you that doing physics with Python is way more fun than the way you did physics in high school or university.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1591,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "pramod-gupta-computational-physics-with-python-planetary-orbits-from-newton-to-feynman",
@@ -11,14 +10,11 @@
   "speakers": [
     "Pramod Gupta"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/NGVBo6JJa6M/maxresdefault.jpg",
   "title": "Computational Physics with Python: Planetary Orbits from Newton to Feynman",
   "videos": [
     {
-      "length": 1591,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=NGVBo6JJa6M"
     }

--- a/pycon-us-2016/videos/pydata-101-essential-data-science-skills-for-every-programmer-from-data-to-model-to-visualization.json
+++ b/pycon-us-2016/videos/pydata-101-essential-data-science-skills-for-every-programmer-from-data-to-model-to-visualization.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speakers: Andy Terrel, Christine Doig\n\nData Science is fun and with the PyData toolset something you can start to build with in an afternoon. Join us as we start with a few datasets, learn how to munge, model, and materialize into simple web applications for predictions. At the end of the day you will come away with a solid understanding of the PyData ecosystem and tools used everyday by data scientists.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 12199,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-29",
   "related_urls": [],
   "slug": "pydata-101-essential-data-science-skills-for-every-programmer-from-data-to-model-to-visualization",
@@ -12,14 +11,11 @@
     "Andy Terrel",
     "Christine Doig"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/rudYHNAGbdk/maxresdefault.jpg",
   "title": "PyData 101: Essential data science skills for every programmer, from data to model to visualization",
   "videos": [
     {
-      "length": 12199,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=rudYHNAGbdk"
     }

--- a/pycon-us-2016/videos/renee-chu-python-for-social-scientists-cleaning-and-prepping-data-pycon-2016.json
+++ b/pycon-us-2016/videos/renee-chu-python-for-social-scientists-cleaning-and-prepping-data-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Renee Chu\n\nIf you're learning to code, working with data is a great way to implement your new skills. However, before you can do analysis or visualization, you must have a cleaned, prepped data set. This tutorial uses Python basics to unify data sets from disparate sources. It also shows you to write your programs as modules so you can re-use them for future projects.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 6906,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-29",
   "related_urls": [],
   "slug": "renee-chu-python-for-social-scientists-cleaning-and-prepping-data-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Renee Chu"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/u682UpVrMVM/maxresdefault.jpg",
   "title": "Python for Social Scientists: Cleaning and Prepping Data",
   "videos": [
     {
-      "length": 6906,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=u682UpVrMVM"
     }

--- a/pycon-us-2016/videos/renee-chu-unit-tests-cluster-tests-a-comparative-introduction-pycon-2016.json
+++ b/pycon-us-2016/videos/renee-chu-unit-tests-cluster-tests-a-comparative-introduction-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Renee Chu\n\nYou've worked on a shared code base and contributed software tests. Great job! But you don't yet know how to set up the holy grail: Having test coverage that's so complete, you can sleep easy knowing any mistake is caught and spoken for. This talk is a \"\"102\"\" level of test talks, describing the different layers of test protection (unit and cluster) and how to approach writing each.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1045,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "renee-chu-unit-tests-cluster-tests-a-comparative-introduction-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Renee Chu"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/VBIufBZiw9Y/maxresdefault.jpg",
   "title": "Unit Tests, Cluster Tests: A Comparative Introduction",
   "videos": [
     {
-      "length": 1045,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=VBIufBZiw9Y"
     }

--- a/pycon-us-2016/videos/ria-baldevia-discovering-the-world-of-python-through-music-pycon-2016.json
+++ b/pycon-us-2016/videos/ria-baldevia-discovering-the-world-of-python-through-music-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Ria Baldevia\n\nThis talk aims to explain how music is a great way to learn Python with Pedro Kroger's  music programming library, Pyknon. In music programming, data structures are really important in order to organize notes, chords, durations, and rests. Eventually, a music programmer will utilize patterns and sequences in order to compose several bars of music.\nThis talk will utilize an animated presentation.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1236,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "ria-baldevia-discovering-the-world-of-python-through-music-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Ria Baldevia"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/JqQDEpdaDmo/maxresdefault.jpg",
   "title": "Discovering the world of Python through music",
   "videos": [
     {
-      "length": 1236,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=JqQDEpdaDmo"
     }

--- a/pycon-us-2016/videos/russell-keith-magee-a-tale-of-two-cellphones-python-on-android-and-ios-pycon-2016.json
+++ b/pycon-us-2016/videos/russell-keith-magee-a-tale-of-two-cellphones-python-on-android-and-ios-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Russell Keith-Magee\n\nPython is enjoying a surge in popularity due to it's features as a language. However, over the last 10 years, mobile platforms have increased in importance, and Python doesn't have a good story on these platforms.\n\nIn this talk, Dr Russell Keith-Magee will give a technical dive into the work the BeeWare project has been doing to make Python as simple to use on Mobile as it is on other platforms.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1960,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "russell-keith-magee-a-tale-of-two-cellphones-python-on-android-and-ios-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Russell Keith-Magee"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/NqdpK9KjGgQ/maxresdefault.jpg",
   "title": "A tale of two cellphones: Python on Android and iOS",
   "videos": [
     {
-      "length": 1960,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=NqdpK9KjGgQ"
     }

--- a/pycon-us-2016/videos/sarah-guido-sean-oconnor-a-tour-of-large-scale-data-analysis-tools-in-python-pycon-2016.json
+++ b/pycon-us-2016/videos/sarah-guido-sean-oconnor-a-tour-of-large-scale-data-analysis-tools-in-python-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speakers: Sarah Guido, Sean O'Connor\n\nLarge-scale data analysis is complicated. There\u2019s a limit to how much data you can analyze on a single box, but it is relatively inexpensive to get access to a large number of commodity servers. In this tutorial, you\u2019ll learn how to leverage the power of distributed computing tools to do large-scale data analysis quickly and affordably using pure Python, Hadoop MapReduce, and Apache Spark.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 10481,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-09",
   "related_urls": [],
   "slug": "sarah-guido-sean-oconnor-a-tour-of-large-scale-data-analysis-tools-in-python-pycon-2016",
@@ -12,14 +11,11 @@
     "Sarah Guido",
     "Sean O'Connor"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/ltS4Om_3QRQ/maxresdefault.jpg",
   "title": "A Tour of Large-Scale Data Analysis Tools in Python",
   "videos": [
     {
-      "length": 10481,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=ltS4Om_3QRQ"
     }

--- a/pycon-us-2016/videos/scott-sanderson-joe-jevnik-playing-with-python-bytecode-pycon-2016.json
+++ b/pycon-us-2016/videos/scott-sanderson-joe-jevnik-playing-with-python-bytecode-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speakers: Scott Sanderson, Joe Jevnik\n\nEver wondered what Python is actually doing when it executes your code?  Want to learn to hand-craft artisanal Python bytecode?  In this talk, we explain CPython's internal code representation, and we demonstrate techniques for modifying code objects for fun and profit.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2511,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "scott-sanderson-joe-jevnik-playing-with-python-bytecode-pycon-2016",
@@ -12,14 +11,11 @@
     "Scott Sanderson",
     "Joe Jevnik"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/mxjv9KqzwjI/maxresdefault.jpg",
   "title": "Playing with Python Bytecode",
   "videos": [
     {
-      "length": 2511,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=mxjv9KqzwjI"
     }

--- a/pycon-us-2016/videos/sean-oconnor-from-developer-to-manager-pycon-2016.json
+++ b/pycon-us-2016/videos/sean-oconnor-from-developer-to-manager-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Sean O'Connor\n\nAs developers move along in their career, they will often be given the chance to move into management. This can be great, but it can also end in tears. In this talk we'll follow one developer's journey into management. Through that process we'll explore what one should think about before embarking on their own journey as well as some lessons for those who do decide to go down the management path.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2810,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "sean-oconnor-from-developer-to-manager-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Sean O'Connor"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/lzBm0r8CxhY/maxresdefault.jpg",
   "title": "From Developer to Manager",
   "videos": [
     {
-      "length": 2810,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=lzBm0r8CxhY"
     }

--- a/pycon-us-2016/videos/sebastian-vetter-click-a-pleasure-to-write-a-pleasure-to-use-pycon-2016.json
+++ b/pycon-us-2016/videos/sebastian-vetter-click-a-pleasure-to-write-a-pleasure-to-use-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Sebastian Vetter\n\nWe have a wide variety of packages and modules in Python that help build commandline tools in different ways. One of the more recent contenders is 'click'. It uses a very intuitive approach to create simple CLIs as well as complex ones. In this talk, I will introduce building CLIs with 'click' and illustrate some of its advantages.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1827,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "sebastian-vetter-click-a-pleasure-to-write-a-pleasure-to-use-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Sebastian Vetter"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/SDyHLG2ltSY/maxresdefault.jpg",
   "title": "Click: A Pleasure To Write, A Pleasure To Use",
   "videos": [
     {
-      "length": 1827,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=SDyHLG2ltSY"
     }

--- a/pycon-us-2016/videos/sep-dehpour-seperman-diff-it-to-dig-it-pycon-2016.json
+++ b/pycon-us-2016/videos/sep-dehpour-seperman-diff-it-to-dig-it-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Sep Dehpour (Seperman)\n\nDo you know about objects __dict__ and __slots__ and what they hold? Hashing unhashables? Objects with loops pointing to themselves? Objects that have changed and you want to know how? No? Then this is the talk for you. In this talk we will learn a lot by diffing Python data types and objects, the same way that you can learn a lot about code by git diff. May the diff habit be with you!\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1541,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "sep-dehpour-seperman-diff-it-to-dig-it-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Sep Dehpour"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/J5r99eJIxF4/maxresdefault.jpg",
   "title": "Diff It To Dig It",
   "videos": [
     {
-      "length": 1541,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=J5r99eJIxF4"
     }

--- a/pycon-us-2016/videos/sev-leonard-the-fellowship-of-the-data-pycon-2016.json
+++ b/pycon-us-2016/videos/sev-leonard-the-fellowship-of-the-data-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Sev Leonard\n\nPython is an excellent tool for gathering, organizing, and storing data. This tutorial will cover efficient & scalable methods for performing these activities as part of an automated data pipeline, enabling attendees to build the One Data Pipeline To Rule Them All.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 6733,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "sev-leonard-the-fellowship-of-the-data-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Sev Leonard"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/n4VLLQXF_9Y/maxresdefault.jpg",
   "title": "The Fellowship of the Data",
   "videos": [
     {
-      "length": 6733,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=n4VLLQXF_9Y"
     }

--- a/pycon-us-2016/videos/shannon-quinn-python-for-public-health-building-statistical-models-of-ciliary-motion-pycon-2016.json
+++ b/pycon-us-2016/videos/shannon-quinn-python-for-public-health-building-statistical-models-of-ciliary-motion-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Shannon Quinn\n\nCilia, microscopic hairs lining nearly every cell surface in your body, play a major role in developmental and sinopulmonary health. As such, deriving quantitative properties of their motion is compelling for both clinical and research purposes. Here we demonstrate a computational pipeline built entirely in Python for analyzing ciliary motion using a variety of machine learning techniques.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1893,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "shannon-quinn-python-for-public-health-building-statistical-models-of-ciliary-motion-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Shannon Quinn"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/TdtrO-pxN2w/maxresdefault.jpg",
   "title": "Python for Public Health: Building Statistical Models of Ciliary Motion",
   "videos": [
     {
-      "length": 1893,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=TdtrO-pxN2w"
     }

--- a/pycon-us-2016/videos/stuart-williams-python-by-immersion-pycon-2016.json
+++ b/pycon-us-2016/videos/stuart-williams-python-by-immersion-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Stuart Williams\n\nA very fast introduction to Python for software developers with experience in other languages.  Instead of a traditional top-down presentation of Python's features, syntax, and semantics, students are immersed in the language bottom-up with hundreds of small examples using the interactive interpreter to quickly gain familiarity with most of the core language features.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 10463,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-09",
   "related_urls": [],
   "slug": "stuart-williams-python-by-immersion-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Stuart Williams"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/9k5687mmnoc/maxresdefault.jpg",
   "title": "Python by Immersion",
   "videos": [
     {
-      "length": 10463,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=9k5687mmnoc"
     }

--- a/pycon-us-2016/videos/stuart-williams-python-epiphanies-pycon-2016.json
+++ b/pycon-us-2016/videos/stuart-williams-python-epiphanies-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: \n\nThis tutorial is for developers who've been using Python for a while and would consider themselves at an intermediate level, but are looking for a deeper understanding of the language.  It focuses on how Python differs from other languages in subtle but important ways that are often confusing, and it demystifies a number of language features that are sometimes misunderstood.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 10189,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "stuart-williams-python-epiphanies-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Stuart Williams"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/6inqFd1bUkE/maxresdefault.jpg",
   "title": "Python Epiphanies",
   "videos": [
     {
-      "length": 10189,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=6inqFd1bUkE"
     }

--- a/pycon-us-2016/videos/sumana-harihareswara-http-can-do-that-pycon-2016.json
+++ b/pycon-us-2016/videos/sumana-harihareswara-http-can-do-that-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Sumana Harihareswara\n\nLearn how to get more performance, testability, and flexibility out of your web apps, using features already built into HTTP. I'll walk you through case studies exploring good (and bad) ideas, using Python, your browser, netcat, and other common tools.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2787,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "sumana-harihareswara-http-can-do-that-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Sumana Harihareswara"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/HsLrXt2l-kg/maxresdefault.jpg",
   "title": "HTTP Can Do That?!",
   "videos": [
     {
-      "length": 2787,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=HsLrXt2l-kg"
     }

--- a/pycon-us-2016/videos/susan-tan-lets-read-code-the-requests-library-pycon-2016.json
+++ b/pycon-us-2016/videos/susan-tan-lets-read-code-the-requests-library-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Susan Tan\n\nImagine you\u2019re a new engineer at a workplace who has to learn a new unfamiliar codebase. After you acquire a copy of the repo, what is your next step? How do you dissect a new unfamiliar codebase to understand its inner workings? Come see a guided walkthrough of reading the widely used python-requests project, which gets over 18,000 downloads per day and powers many of the world\u2019s REST-based APIs.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1522,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "susan-tan-lets-read-code-the-requests-library-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Susan Tan"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/_KcjSQ0gjFs/maxresdefault.jpg",
   "title": "Let's read code: the requests library",
   "videos": [
     {
-      "length": 1522,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=_KcjSQ0gjFs"
     }

--- a/pycon-us-2016/videos/thank-you.json
+++ b/pycon-us-2016/videos/thank-you.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "",
   "duration": 252,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "thank-you",
@@ -11,14 +10,11 @@
   "speakers": [
     "Brandon Rhodes"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/RNmO_OfJ0Hs/maxresdefault.jpg",
   "title": "Thank you",
   "videos": [
     {
-      "length": 252,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=RNmO_OfJ0Hs"
     }

--- a/pycon-us-2016/videos/the-report-of-twisteds-death-or-why-twisted-and-tornado-are-relevant-in-the-asyncio-age.json
+++ b/pycon-us-2016/videos/the-report-of-twisteds-death-or-why-twisted-and-tornado-are-relevant-in-the-asyncio-age.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Amber Brown\n\nWith asyncio on the scene, the question has been asked: is there any point in having Twisted or Tornado around?\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 2689,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "the-report-of-twisteds-death-or-why-twisted-and-tornado-are-relevant-in-the-asyncio-age",
@@ -11,14 +10,11 @@
   "speakers": [
     "Amber Brown"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/82vuCZ4FLFE/maxresdefault.jpg",
   "title": "The Report Of Twisted\u2019s Death or: Why Twisted and Tornado Are Relevant In The Asyncio Age",
   "videos": [
     {
-      "length": 2689,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=82vuCZ4FLFE"
     }

--- a/pycon-us-2016/videos/thomas-ballinger-finding-closure-with-closures-pycon-2016.json
+++ b/pycon-us-2016/videos/thomas-ballinger-finding-closure-with-closures-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Thomas Ballinger\n\nWhat are closures all about anyway, and why is there a new keyword in Python\n3?\nWe'll look at what a closure is, their history in the Python language, what\nthe Python 3 nonlocal keyword is about, and examine how closures are\nidiomatically used (and avoided) in Python.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1866,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "thomas-ballinger-finding-closure-with-closures-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Thomas Ballinger"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/E9wS6LdXM8Y/maxresdefault.jpg",
   "title": "Finding closure with closures",
   "videos": [
     {
-      "length": 1866,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=E9wS6LdXM8Y"
     }

--- a/pycon-us-2016/videos/tony-ojeda-benjamin-bengfort-laura-lorenz-natural-language-processing-with-nltk-and-gensim.json
+++ b/pycon-us-2016/videos/tony-ojeda-benjamin-bengfort-laura-lorenz-natural-language-processing-with-nltk-and-gensim.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speakers: Tony Ojeda, Benjamin Bengfort, Laura Lorenz\n\nIn this tutorial, we will begin by exploring the features of the NLTK library. We will then focus on building a language-aware data product - a topic identification and document clustering algorithm from a web crawl of blog sites. The clustering algorithm will use a simple Lesk K-Means clustering to start, and then will improve with an LDA analysis using the popular Gensim library.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 10977,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "tony-ojeda-benjamin-bengfort-laura-lorenz-natural-language-processing-with-nltk-and-gensim",
@@ -13,14 +12,11 @@
     "Benjamin Bengfort",
     "Laura Lorenz"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/itKNpCPHq3I/maxresdefault.jpg",
   "title": "Natural Language Processing with NLTK and Gensim",
   "videos": [
     {
-      "length": 10977,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=itKNpCPHq3I"
     }

--- a/pycon-us-2016/videos/tracy-osborn-build-your-first-web-app-with-hello-web-app-pycon-2016.json
+++ b/pycon-us-2016/videos/tracy-osborn-build-your-first-web-app-with-hello-web-app-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Tracy Osborn\n\nThis workshop will walk you through creating a basic web app using Python and Django, from ideation to deployment. Set up your first web product with a database, registration and login forms, and perhaps get on the path to a fun side-project or future startup. Tailored for designers and non-programmers and taught by a designer.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 9006,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-29",
   "related_urls": [],
   "slug": "tracy-osborn-build-your-first-web-app-with-hello-web-app-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Tracy Osborn"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/lKEyKpZVP00/maxresdefault.jpg",
   "title": "Build Your First Web App with Hello Web App!",
   "videos": [
     {
-      "length": 9006,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=lKEyKpZVP00"
     }

--- a/pycon-us-2016/videos/tracy-osborn-web-design-for-non-designers-pycon-2016.json
+++ b/pycon-us-2016/videos/tracy-osborn-web-design-for-non-designers-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Tracy Osborn\n\nWhen you are a programmer, web design can be super intimidating but still necessary for your websites and web apps. This talk will highlight the best ways to improve your design and UX skills so you can create an interfaces that are usable and at least semi-attractive without hiring a designer \u2014 guaranteed no designer-y jargon.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1902,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-20",
   "related_urls": [],
   "slug": "tracy-osborn-web-design-for-non-designers-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Tracy Osborn"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/uKpfO331DY4/maxresdefault.jpg",
   "title": "Web Design for Non Designers",
   "videos": [
     {
-      "length": 1902,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=uKpfO331DY4"
     }

--- a/pycon-us-2016/videos/tracy-teal-data-carpentry-an-introduction-to-python-for-data-analysis-and-visualization.json
+++ b/pycon-us-2016/videos/tracy-teal-data-carpentry-an-introduction-to-python-for-data-analysis-and-visualization.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Tracy Teal\n\nIn most domains of research & industry, the increasing capacity to generate data means people need effective computational skills to turn this data into knowledge. We will teach participants how to get started with data analysis & visualization in Python. Skills taught are focused on novices & will enable participants to begin working with their own data & provide the basis for continued learning.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 10455,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "tracy-teal-data-carpentry-an-introduction-to-python-for-data-analysis-and-visualization",
@@ -11,14 +10,11 @@
   "speakers": [
     "Tracy Teal"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/Ws34Ho-1aDs/maxresdefault.jpg",
   "title": "Data Carpentry: An Introduction to Python for Data Analysis and Visualization",
   "videos": [
     {
-      "length": 10455,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=Ws34Ho-1aDs"
     }

--- a/pycon-us-2016/videos/trey-hunner-regular-expressions-pycon-2016.json
+++ b/pycon-us-2016/videos/trey-hunner-regular-expressions-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Trey Hunner\n\nWhat are regular expressions, what are they useful for, and why are they so hard to read?  We'll learn what regular expressions are good for, how to make our own regular expressions, and how to make our regular expressions friendly and readable (yes it's possible, sort of).\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 6121,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-09",
   "related_urls": [],
   "slug": "trey-hunner-regular-expressions-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Trey Hunner"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/W4ReH9IPH-Q/maxresdefault.jpg",
   "title": "Regular Expressions",
   "videos": [
     {
-      "length": 6121,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=W4ReH9IPH-Q"
     }

--- a/pycon-us-2016/videos/tyler-reddy-computational-geometry-in-python-pycon-2016.json
+++ b/pycon-us-2016/videos/tyler-reddy-computational-geometry-in-python-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Tyler Reddy\n\nComputational geometry deals with the algorithms used to solve a diverse set of problems in geometry. Applications range from robotics (visibility) and geographic information systems to game development (collision detection) and medical research. This tutorial will introduce computational geometry, the related tools available in the Python ecosystem, and identify areas for improvement.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 9291,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "tyler-reddy-computational-geometry-in-python-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Tyler Reddy"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/nb3GRgtjlTw/maxresdefault.jpg",
   "title": "Computational Geometry in Python",
   "videos": [
     {
-      "length": 9291,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=nb3GRgtjlTw"
     }

--- a/pycon-us-2016/videos/ukasz-langa-thinking-in-coroutines-pycon-2016.json
+++ b/pycon-us-2016/videos/ukasz-langa-thinking-in-coroutines-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: \u0141ukasz Langa\n\nThe wait for the killer feature of Python 3 is over! Come learn about asyncio and the beauty of event loops, coroutines, futures, executors and the mighty async/await. Practical examples. Bad puns. Pretty pictures. No prior asyncore, Twisted or Node.js experience required.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1638,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "ukasz-langa-thinking-in-coroutines-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "\u0141ukasz Langa"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/l4Nn-y9ktd4/maxresdefault.jpg",
   "title": "Thinking In Coroutines",
   "videos": [
     {
-      "length": 1638,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=l4Nn-y9ktd4"
     }

--- a/pycon-us-2016/videos/van-lindberg-python-software-foundation-pycon-2016.json
+++ b/pycon-us-2016/videos/van-lindberg-python-software-foundation-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Van Lindberg\n\nPython Software Foundation\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1769,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-01",
   "related_urls": [],
   "slug": "van-lindberg-python-software-foundation-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Van Lindberg"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/Bo1UqxTnp1s/maxresdefault.jpg",
   "title": "Python Software Foundation",
   "videos": [
     {
-      "length": 1769,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=Bo1UqxTnp1s"
     }

--- a/pycon-us-2016/videos/van-lindberg-structured-data-from-unstructured-text-pycon-2016.json
+++ b/pycon-us-2016/videos/van-lindberg-structured-data-from-unstructured-text-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Van Lindberg\n\nEver wonder how if you google \u201cWhen was Python created?\u201d Google just has the answer in a box at the top for you?  In this talk we\u2019ll investigate how information extraction systems work, implement one using scikit-learn and NLTK, and learn about natural language processing along the way.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1655,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-20",
   "related_urls": [],
   "slug": "van-lindberg-structured-data-from-unstructured-text-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Van Lindberg"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/-K-XtxSyyvU/maxresdefault.jpg",
   "title": "Structured Data from Unstructured Text",
   "videos": [
     {
-      "length": 1655,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=-K-XtxSyyvU"
     }

--- a/pycon-us-2016/videos/visual-diagnostics-for-more-informed-machine-learning-within-and-beyond-scikit-learn-pycon-2016.json
+++ b/pycon-us-2016/videos/visual-diagnostics-for-more-informed-machine-learning-within-and-beyond-scikit-learn-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Rebecca Bilbro\n\nVisualization has a critical role to play throughout the analytic process. Where static outputs and tabular data may render patterns opaque, human visual analysis can uncover volumes and lead to more robust programming and better data products. For Python programmers who dabble in machine learning, visual diagnostics are a must-have for effective feature analysis, model selection, and evaluation.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1460,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-06-16",
   "related_urls": [],
   "slug": "visual-diagnostics-for-more-informed-machine-learning-within-and-beyond-scikit-learn-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Rebecca Bilbro"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/c5DaaGZWQqY/hqdefault.jpg",
   "title": "Visual Diagnostics for More Informed Machine Learning Within and Beyond Scikit-Learn",
   "videos": [
     {
-      "length": 1460,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=c5DaaGZWQqY"
     }

--- a/pycon-us-2016/videos/wendy-grus-when-is-it-good-to-be-bad-web-scraping-and-data-analysis-of-nhl-penalties-pycon-2016.json
+++ b/pycon-us-2016/videos/wendy-grus-when-is-it-good-to-be-bad-web-scraping-and-data-analysis-of-nhl-penalties-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speaker: Wendy Grus\n\nOn Jan. 20, Philadelphia Flyers forward Zac Rinaldo was ejected from a game after boarding Penguins defenseman Kris Letang. The Flyers came back to win. After the game, Rinaldo said he \"\"changed the game\"\" (for which he was suspended 8 games). Using Python for webscraping and data analysis, I explore data from 10 NHL seasons to investigate how hockey penalties affect the outcome of the game.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1820,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-31",
   "related_urls": [],
   "slug": "wendy-grus-when-is-it-good-to-be-bad-web-scraping-and-data-analysis-of-nhl-penalties-pycon-2016",
@@ -11,14 +10,11 @@
   "speakers": [
     "Wendy Grus"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/uW02_GnQKeM/maxresdefault.jpg",
   "title": "When is it good to be bad? Web scraping and data analysis of NHL penalties",
   "videos": [
     {
-      "length": 1820,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=uW02_GnQKeM"
     }

--- a/pycon-us-2016/videos/ying-li-david-lawrence-when-the-going-gets-tough-get-tuf-going-pycon-2016.json
+++ b/pycon-us-2016/videos/ying-li-david-lawrence-when-the-going-gets-tough-get-tuf-going-pycon-2016.json
@@ -1,9 +1,8 @@
 {
-  "category": "PyCon US 2016",
   "copyright_text": "Standard YouTube License",
   "description": "Speakers: Ying Li, David Lawrence\n\nThe Update Framework (TUF) helps developers secure new or existing software update systems by providing integrity and freshness guarantees over package distribution. Integrate TUF into your deployment pipelines to provide integrity and version guarantees for build and deployment artifacts.\n\nSlides can be found at: https://speakerdeck.com/pycon2016 and https://github.com/PyCon/2016-slides",
   "duration": 1627,
-  "language": "English",
+  "language": "eng",
   "recorded": "2016-05-30",
   "related_urls": [],
   "slug": "ying-li-david-lawrence-when-the-going-gets-tough-get-tuf-going-pycon-2016",
@@ -12,14 +11,11 @@
     "Ying Li",
     "David Lawrence"
   ],
-  "state": 2,
-  "summary": "",
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/fDvO9jwXCV4/maxresdefault.jpg",
   "title": "When the going gets tough, get TUF going",
   "videos": [
     {
-      "length": 1627,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=fDvO9jwXCV4"
     }


### PR DESCRIPTION
As commented in #57, the following have been cleaned:
- [x] delete `"state": 2` values
- [x] delete `"category": "PyCon US 2016",` values (deprecated in video files).
- [x] change ` "language": "English",` to ` "language": "eng",`
- [x] delete void summaries `"summary": "",` 
- [x] delete `"length": ` values in `"videos": [ { ` misinterpreted by me as seconds