### PR TITLE
Delete "date" (Deprecated). Not in use in the repository.

### DIFF
--- a/.schemas/video.json
+++ b/.schemas/video.json
@@ -14,13 +14,8 @@
       "description":"Copyright license for video or link to copyright information.",
       "anyOf": [{"type": "null"}, {"type": "string"}]
     },
-    "date":{
-      "description":"[Deprecated] Date on which video was recorded (YYYY-MM-DD). Please use 'recorded' instead.",
-      "anyOf": [{"type": "null"}, {"type": "string"}],
-      "format":"date-time"
-    },
     "description":{
-      "description":"reStrucutredText or plain text description of video",
+      "description":"reStructuredText or plain text description of video",
       "anyOf": [{"type": "null"}, {"type": "string"}]
     },
     "duration":{


### PR DESCRIPTION
Field "date" deleted
Field "date" Deprecated + not found in any video file. (Not seen in `tools/video_statistics.py .`)
