### PR TITLE
Patch remove source url

### DIFF
--- a/.schemas/video.json
+++ b/.schemas/video.json
@@ -53,11 +53,6 @@
       "description":"Web-safe slug for video. Must be unique amongst other videos in same category",
       "anyOf": [{"type": "null"}, {"type": "string"}]
     },
-    "source_url":{
-      "description":"[Deprecated] Preferred URL for video.",
-      "format":"uri",
-      "anyOf": [{"type": "null"}, {"type": "string"}]
-    },
     "speakers":{
       "description":"Ordered array of speakers in video.",
       "items":{

--- a/chipy/videos/blender-2-5-loves-python-3.json
+++ b/chipy/videos/blender-2-5-loves-python-3.json
@@ -12,7 +12,6 @@
     "http://chipy.org/"
   ],
   "slug": "blender-2-5-loves-python-3",
-  "source_url": "http://blip.tv/file/2785963",
   "speakers": [
     "Christopher Allan Webber"
   ],

--- a/chipy/videos/python-django-deployment.json
+++ b/chipy/videos/python-django-deployment.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2011-02-10",
   "slug": "python-django-deployment",
-  "source_url": "http://blip.tv/file/4754795",
   "speakers": [
     "Rohit Sankaran"
   ],

--- a/chipy/videos/rest-ful-web-apps-with-django-piston.json
+++ b/chipy/videos/rest-ful-web-apps-with-django-piston.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2009-12-10",
   "slug": "rest-ful-web-apps-with-django-piston",
-  "source_url": "http://blip.tv/file/2964989",
   "speakers": [],
   "summary": "A common complaint about Django, the leading Python web application\nframework, is that it doesn't make writing REST APIs easy enough. In\nfact the paradigm for a typical Django application involves views which\nmap to HTML page templates. With end users increasingly expecting rich\ninterfaces with the responsiveness of a desktop application, this\nparadigm is being superseded. Fortunately a third-party Django\napplication called Piston fills the gap. Django/Piston can be combined\nwith the Ext JS JavaScript framework and widget set to create\nattractive, responsive Web applications, and this talk will show you\nhow.\n",
   "tags": [

--- a/djangocon-2010/videos/djangocon-2010--switching-addons-mozilla-org-from.json
+++ b/djangocon-2010/videos/djangocon-2010--switching-addons-mozilla-org-from.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2010-09-07",
   "slug": "djangocon-2010--switching-addons-mozilla-org-from",
-  "source_url": "http://blip.tv/file/4106752",
   "speakers": [
     "Jeff Balogh"
   ],

--- a/pycon-us-2009/videos/pycon-2009--plenary--sprint-intro.json
+++ b/pycon-us-2009/videos/pycon-2009--plenary--sprint-intro.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": null,
   "slug": "pycon-2009--plenary--sprint-intro",
-  "source_url": "http://blip.tv/file/1957750",
   "speakers": [],
   "summary": "",
   "tags": [

--- a/pycon-za-2012/videos/pycon-za-2012-introduction-to-sqlalchemy.json
+++ b/pycon-za-2012/videos/pycon-za-2012-introduction-to-sqlalchemy.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-05",
   "slug": "pycon-za-2012-introduction-to-sqlalchemy",
-  "source_url": "http://archive.org/details/pyconza2012-sqlalchemy",
   "speakers": [
     "David Fraser"
   ],

--- a/pycon-za-2012/videos/pycon-za-2012-introduction-to-the-plone-content.json
+++ b/pycon-za-2012/videos/pycon-za-2012-introduction-to-the-plone-content.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-05",
   "slug": "pycon-za-2012-introduction-to-the-plone-content",
-  "source_url": "http://archive.org/details/pyconza2012-plone",
   "speakers": [
     "Jan-Carel Brand"
   ],

--- a/pycon-za-2012/videos/pyconza-2012-building-restful-service-oriented.json
+++ b/pycon-za-2012/videos/pyconza-2012-building-restful-service-oriented.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-04",
   "slug": "pyconza-2012-building-restful-service-oriented",
-  "source_url": "http://archive.org/details/pyconza2012-RESTful_twisted",
   "speakers": [
     "Bryn Divey"
   ],

--- a/pycon-za-2012/videos/pyconza-2012-changing-from-net-to-python.json
+++ b/pycon-za-2012/videos/pyconza-2012-changing-from-net-to-python.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-05",
   "slug": "pyconza-2012-changing-from-net-to-python",
-  "source_url": "http://archive.org/details/pyconza2012-changing_from_net",
   "speakers": [
     "David Campey"
   ],

--- a/pycon-za-2012/videos/pyconza-2012-control-and-monitoring-of-the-karoo.json
+++ b/pycon-za-2012/videos/pyconza-2012-control-and-monitoring-of-the-karoo.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-04",
   "slug": "pyconza-2012-control-and-monitoring-of-the-karoo",
-  "source_url": "http://archive.org/details/pyconza2012-monitoring_kat",
   "speakers": [
     "Charles de Villiers",
     "Neilen Marais"

--- a/pycon-za-2012/videos/pyconza-2012-details-of-python-performance.json
+++ b/pycon-za-2012/videos/pyconza-2012-details-of-python-performance.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-04",
   "slug": "pyconza-2012-details-of-python-performance",
-  "source_url": "http://archive.org/details/pyconza2012-performance",
   "speakers": [
     "Maciej Fija\u0142kowski"
   ],

--- a/pycon-za-2012/videos/pyconza-2012-fractal-architectures.json
+++ b/pycon-za-2012/videos/pyconza-2012-fractal-architectures.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-05",
   "slug": "pyconza-2012-fractal-architectures",
-  "source_url": "http://archive.org/details/pyconza2012-fractal",
   "speakers": [
     "Laurens Van Houtven"
   ],

--- a/pycon-za-2012/videos/pyconza-2012-high-performance-computing-with-pyt.json
+++ b/pycon-za-2012/videos/pyconza-2012-high-performance-computing-with-pyt.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-04",
   "slug": "pyconza-2012-high-performance-computing-with-pyt",
-  "source_url": "http://archive.org/details/pyconza2012-high_performance",
   "speakers": [
     "Andy Rabagliati",
     "Kevin Colville"

--- a/pycon-za-2012/videos/pyconza-2012-how-to-open-a-bar-in-python.json
+++ b/pycon-za-2012/videos/pyconza-2012-how-to-open-a-bar-in-python.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-04",
   "slug": "pyconza-2012-how-to-open-a-bar-in-python",
-  "source_url": "http://archive.org/details/pyconza2012-howto-bar",
   "speakers": [
     "Edward van Kuik"
   ],

--- a/pycon-za-2012/videos/pyconza-2012-hyperion-development-teaching-and.json
+++ b/pycon-za-2012/videos/pyconza-2012-hyperion-development-teaching-and.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-04",
   "slug": "pyconza-2012-hyperion-development-teaching-and",
-  "source_url": "http://archive.org/details/pyconza2012-hyperion",
   "speakers": [
     "Orion Adams"
   ],

--- a/pycon-za-2012/videos/pyconza-2012-meerkat-science-with-python.json
+++ b/pycon-za-2012/videos/pyconza-2012-meerkat-science-with-python.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-04",
   "slug": "pyconza-2012-meerkat-science-with-python",
-  "source_url": "http://archive.org/details/pyconza2012-meerkat",
   "speakers": [
     "Simon Ratcliffe"
   ],

--- a/pycon-za-2012/videos/pyconza-2012-our-hybrid-programming-journey-with.json
+++ b/pycon-za-2012/videos/pyconza-2012-our-hybrid-programming-journey-with.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-05",
   "slug": "pyconza-2012-our-hybrid-programming-journey-with",
-  "source_url": "http://archive.org/details/pyconza2012-hybrid",
   "speakers": [
     "James Saunders"
   ],

--- a/pycon-za-2012/videos/pyconza-2012-pyconza-by-the-numbers.json
+++ b/pycon-za-2012/videos/pyconza-2012-pyconza-by-the-numbers.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-04",
   "slug": "pyconza-2012-pyconza-by-the-numbers",
-  "source_url": "http://archive.org/details/pyconza2012-opening",
   "speakers": [
     "Gustav Praekelt"
   ],

--- a/pycon-za-2012/videos/pyconza-2012-pypy.json
+++ b/pycon-za-2012/videos/pyconza-2012-pypy.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-04",
   "slug": "pyconza-2012-pypy",
-  "source_url": "http://archive.org/details/pyconza2012-pypy",
   "speakers": [
     "Armin Rigo"
   ],

--- a/pycon-za-2012/videos/pyconza-2012-python-in-the-real-world-healthcar.json
+++ b/pycon-za-2012/videos/pyconza-2012-python-in-the-real-world-healthcar.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-04",
   "slug": "pyconza-2012-python-in-the-real-world-healthcar",
-  "source_url": "http://archive.org/details/pyconza2012-healthcare",
   "speakers": [
     "Dr. Brain Leke Betachuoh",
     "Suparna Apte"

--- a/pycon-za-2012/videos/pyconza-2012-scalable-event-driven-architectures.json
+++ b/pycon-za-2012/videos/pyconza-2012-scalable-event-driven-architectures.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-04",
   "slug": "pyconza-2012-scalable-event-driven-architectures",
-  "source_url": "http://archive.org/details/pyconza2012-scalable",
   "speakers": [
     "Simon de Haan"
   ],

--- a/pycon-za-2012/videos/pyconza-2012-scaling-django-serving-traffic-and.json
+++ b/pycon-za-2012/videos/pyconza-2012-scaling-django-serving-traffic-and.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-04",
   "slug": "pyconza-2012-scaling-django-serving-traffic-and",
-  "source_url": "http://archive.org/details/pyconza2012-scaling_django",
   "speakers": [
     "Alex Gaynor"
   ],

--- a/pycon-za-2012/videos/pyconza-2012-stepping-through-cpython.json
+++ b/pycon-za-2012/videos/pyconza-2012-stepping-through-cpython.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-04",
   "slug": "pyconza-2012-stepping-through-cpython",
-  "source_url": "http://archive.org/details/pyconza2012-cpython",
   "speakers": [
     "Larry Hastings"
   ],

--- a/pycon-za-2012/videos/pyconza-2012-things-you-didnt-know-about-python.json
+++ b/pycon-za-2012/videos/pyconza-2012-things-you-didnt-know-about-python.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-05",
   "slug": "pyconza-2012-things-you-didnt-know-about-python",
-  "source_url": "http://archive.org/details/pyconza2012-things",
   "speakers": [
     "Armin Ronacher"
   ],

--- a/pycon-za-2012/videos/pyconza-2012-why-php-is-a-terrible-addiction-to.json
+++ b/pycon-za-2012/videos/pyconza-2012-why-php-is-a-terrible-addiction-to.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2012-10-05",
   "slug": "pyconza-2012-why-php-is-a-terrible-addiction-to",
-  "source_url": "http://archive.org/details/pyconza2012-php",
   "speakers": [
     "Bradley Whittington"
   ],

--- a/pycon-za-2013/videos/a-random-walk-in-image-processing-with-scikit-ima.json
+++ b/pycon-za-2013/videos/a-random-walk-in-image-processing-with-scikit-ima.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "a-random-walk-in-image-processing-with-scikit-ima",
-  "source_url": "http://archive.org/details/pyconza2013-scikit-image",
   "speakers": [
     "Stefan van der Walt"
   ],

--- a/pycon-za-2013/videos/a-real-world-example-of-caching-gone-wrong-part-0.json
+++ b/pycon-za-2013/videos/a-real-world-example-of-caching-gone-wrong-part-0.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "a-real-world-example-of-caching-gone-wrong-part-0",
-  "source_url": "http://archive.org/details/pyconza2013-caching-gone-wrong-pt2",
   "speakers": [
     "Matt Hampton"
   ],

--- a/pycon-za-2013/videos/a-real-world-example-of-caching-gone-wrong-part.json
+++ b/pycon-za-2013/videos/a-real-world-example-of-caching-gone-wrong-part.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "a-real-world-example-of-caching-gone-wrong-part",
-  "source_url": "http://archive.org/details/pyconza2013-caching-gone-wrong-pt1",
   "speakers": [
     "Matt Hampton"
   ],

--- a/pycon-za-2013/videos/all-singing-all-dancing-python-bytecode-0.json
+++ b/pycon-za-2013/videos/all-singing-all-dancing-python-bytecode-0.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "all-singing-all-dancing-python-bytecode-0",
-  "source_url": "http://archive.org/details/pyconza2013-python-bytecode",
   "speakers": [
     "Larry Hastings"
   ],

--- a/pycon-za-2013/videos/an-introduction-to-flask.json
+++ b/pycon-za-2013/videos/an-introduction-to-flask.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "an-introduction-to-flask",
-  "source_url": "http://archive.org/details/pyconza2013-intro-to-flask",
   "speakers": [
     "Adrianna Pi\u0144ska"
   ],

--- a/pycon-za-2013/videos/application-to-platform-how-we-used-python-to-sc.json
+++ b/pycon-za-2013/videos/application-to-platform-how-we-used-python-to-sc.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "application-to-platform-how-we-used-python-to-sc",
-  "source_url": "http://archive.org/details/pyconza2013-app-to-platform",
   "speakers": [
     "Michael Joseph"
   ],

--- a/pycon-za-2013/videos/building-the-ska.json
+++ b/pycon-za-2013/videos/building-the-ska.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "building-the-ska",
-  "source_url": "http://archive.org/details/build-the-ska",
   "speakers": [
     "Simon Ratcliffe"
   ],

--- a/pycon-za-2013/videos/everything-was-python-and-nothing-hurt.json
+++ b/pycon-za-2013/videos/everything-was-python-and-nothing-hurt.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "everything-was-python-and-nothing-hurt",
-  "source_url": "http://archive.org/details/pyconza2013-nothing-hurt",
   "speakers": [
     "Sett Wai"
   ],

--- a/pycon-za-2013/videos/hack-where-it-matters-part-1.json
+++ b/pycon-za-2013/videos/hack-where-it-matters-part-1.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "hack-where-it-matters-part-1",
-  "source_url": "http://archive.org/details/pyconza2013-hack-matters-pt1",
   "speakers": [
     "Simon de Haan"
   ],

--- a/pycon-za-2013/videos/hack-where-it-matters-part-2.json
+++ b/pycon-za-2013/videos/hack-where-it-matters-part-2.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "hack-where-it-matters-part-2",
-  "source_url": "http://archive.org/details/pyconza2013-hack-matters-pt2",
   "speakers": [
     "Simon de Haan"
   ],

--- a/pycon-za-2013/videos/harmonies-and-hues.json
+++ b/pycon-za-2013/videos/harmonies-and-hues.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "harmonies-and-hues",
-  "source_url": "http://archive.org/details/pyconza2013-harmonies-and-hues",
   "speakers": [
     "David Fraser"
   ],

--- a/pycon-za-2013/videos/how-to-increase-the-reach-and-impact-of-your-appl.json
+++ b/pycon-za-2013/videos/how-to-increase-the-reach-and-impact-of-your-appl.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "how-to-increase-the-reach-and-impact-of-your-appl",
-  "source_url": "http://archive.org/details/pyconza2013-increase-impact",
   "speakers": [
     "Zafack Takadong"
   ],

--- a/pycon-za-2013/videos/idea-to-launch-in-days-executed-python-style.json
+++ b/pycon-za-2013/videos/idea-to-launch-in-days-executed-python-style.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "idea-to-launch-in-days-executed-python-style",
-  "source_url": "http://archive.org/details/pyconza2013-idea-to-launch",
   "speakers": [
     "Mike Jones"
   ],

--- a/pycon-za-2013/videos/our-journey-to-kivy.json
+++ b/pycon-za-2013/videos/our-journey-to-kivy.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "our-journey-to-kivy",
-  "source_url": "http://archive.org/details/pyconza2013-journey-to-kivy",
   "speakers": [
     "Richard Larkin"
   ],

--- a/pycon-za-2013/videos/panel-discussion-effective-team-practices-in-sof-0.json
+++ b/pycon-za-2013/videos/panel-discussion-effective-team-practices-in-sof-0.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "panel-discussion-effective-team-practices-in-sof-0",
-  "source_url": "http://archive.org/details/pyconza2013-panel-discussion-pt2",
   "speakers": [],
   "summary": "",
   "tags": [

--- a/pycon-za-2013/videos/panel-discussion-effective-team-practices-in-sof.json
+++ b/pycon-za-2013/videos/panel-discussion-effective-team-practices-in-sof.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "panel-discussion-effective-team-practices-in-sof",
-  "source_url": "http://archive.org/details/pyconza2013-panel-discussion-pt1",
   "speakers": [
     "Panel"
   ],

--- a/pycon-za-2013/videos/php-interpreter-using-pypy-technology.json
+++ b/pycon-za-2013/videos/php-interpreter-using-pypy-technology.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "php-interpreter-using-pypy-technology",
-  "source_url": "http://archive.org/details/pyconza2013-pypy-php",
   "speakers": [
     "Maciej Fija\u0142kowski"
   ],

--- a/pycon-za-2013/videos/pyconza-2013-deploying-highly-available-architec.json
+++ b/pycon-za-2013/videos/pyconza-2013-deploying-highly-available-architec.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "pyconza-2013-deploying-highly-available-architec",
-  "source_url": "http://archive.org/details/pyconza2013-pinch-of-salt",
   "speakers": [
     "Petrus Theron"
   ],

--- a/pycon-za-2013/videos/pyconza-2013-lightning-talks.json
+++ b/pycon-za-2013/videos/pyconza-2013-lightning-talks.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "pyconza-2013-lightning-talks",
-  "source_url": "http://archive.org/details/pyconza2013-lightning-talks",
   "speakers": [],
   "summary": "Multiple people's talk at PyConZA 2013\n",
   "tags": [

--- a/pycon-za-2013/videos/pyconza-2013-opening-ceremony.json
+++ b/pycon-za-2013/videos/pyconza-2013-opening-ceremony.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "pyconza-2013-opening-ceremony",
-  "source_url": "http://archive.org/details/conference-opening",
   "speakers": [
     "Simon Cross"
   ],

--- a/pycon-za-2013/videos/python-frontends-for-cfd.json
+++ b/pycon-za-2013/videos/python-frontends-for-cfd.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "python-frontends-for-cfd",
-  "source_url": "http://archive.org/details/pyconza2013-python-cfd",
   "speakers": [
     "Andrew Gill",
     "Kevin Colville"

--- a/pycon-za-2013/videos/python-in-debian-and-ubuntu.json
+++ b/pycon-za-2013/videos/python-in-debian-and-ubuntu.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "python-in-debian-and-ubuntu",
-  "source_url": "http://archive.org/details/pyconza2013-python-in-debian",
   "speakers": [
     "Stefano Rivera"
   ],

--- a/pycon-za-2013/videos/python-meta-classes.json
+++ b/pycon-za-2013/videos/python-meta-classes.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "python-meta-classes",
-  "source_url": "http://archive.org/details/pyconza2013-meta-classes",
   "speakers": [
     "Kisitu Augustine"
   ],

--- a/pycon-za-2013/videos/software-transactional-memory-with-pypy.json
+++ b/pycon-za-2013/videos/software-transactional-memory-with-pypy.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2013-10-03",
   "slug": "software-transactional-memory-with-pypy",
-  "source_url": "http://archive.org/details/pyconza2013-pypy-stm",
   "speakers": [
     "Armin Rigo"
   ],

--- a/pycon-za-2014/videos/a-journey-through-the-eyes-of-a-newbie-female-dev.json
+++ b/pycon-za-2014/videos/a-journey-through-the-eyes-of-a-newbie-female-dev.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-03",
   "slug": "a-journey-through-the-eyes-of-a-newbie-female-dev",
-  "source_url": "http://archive.org/details/pyconza2014-journey-through-eyes-of-newbie-female-developer",
   "speakers": [
     "Ridhwana Khan"
   ],

--- a/pycon-za-2014/videos/an-introduction-to-regular-expressions-in-python.json
+++ b/pycon-za-2014/videos/an-introduction-to-regular-expressions-in-python.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-03",
   "slug": "an-introduction-to-regular-expressions-in-python",
-  "source_url": "http://archive.org/details/pyconza2014-regular-expressions",
   "speakers": [
     "Adrianna Pi\u0144ska"
   ],

--- a/pycon-za-2014/videos/building-the-internet-of-things-with-raspberry-pi.json
+++ b/pycon-za-2014/videos/building-the-internet-of-things-with-raspberry-pi.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-02",
   "slug": "building-the-internet-of-things-with-raspberry-pi",
-  "source_url": "http://archive.org/details/pyconza2014-raspberry-pi-internet-of-things",
   "speakers": [
     "Neil Broers"
   ],

--- a/pycon-za-2014/videos/challenges-and-prospects-of-the-python-african-co.json
+++ b/pycon-za-2014/videos/challenges-and-prospects-of-the-python-african-co.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-03",
   "slug": "challenges-and-prospects-of-the-python-african-co",
-  "source_url": "http://archive.org/details/pyconza2014-python-african-csae-tour",
   "speakers": [
     "Godfrey Akpojotor"
   ],

--- a/pycon-za-2014/videos/enabling-science-with-the-southern-african-large.json
+++ b/pycon-za-2014/videos/enabling-science-with-the-southern-african-large.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-02",
   "slug": "enabling-science-with-the-southern-african-large",
-  "source_url": "http://archive.org/details/pyconza2014-enabling-science-with-salt",
   "speakers": [
     "Steve Crawford"
   ],

--- a/pycon-za-2014/videos/hand-me-the-salt-while-i-read-my-news.json
+++ b/pycon-za-2014/videos/hand-me-the-salt-while-i-read-my-news.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-02",
   "slug": "hand-me-the-salt-while-i-read-my-news",
-  "source_url": "http://archive.org/details/pyconza2014-salt-while-read-news",
   "speakers": [
     "Johann du Toit"
   ],

--- a/pycon-za-2014/videos/how-i-became-a-cookie-monster.json
+++ b/pycon-za-2014/videos/how-i-became-a-cookie-monster.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-03",
   "slug": "how-i-became-a-cookie-monster",
-  "source_url": "http://archive.org/details/pyconza2014-cookie-monster",
   "speakers": [
     "Michael Joseph"
   ],

--- a/pycon-za-2014/videos/how-python-helps-writing-documentation-less-painf.json
+++ b/pycon-za-2014/videos/how-python-helps-writing-documentation-less-painf.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-03",
   "slug": "how-python-helps-writing-documentation-less-painf",
-  "source_url": "http://archive.org/details/pyconza2014-python-helps-make-writing-docs-less-painful",
   "speakers": [
     "Nickolas Grigoriadis"
   ],

--- a/pycon-za-2014/videos/inspired-by-lisp-to-get-ruby-to-talk-python.json
+++ b/pycon-za-2014/videos/inspired-by-lisp-to-get-ruby-to-talk-python.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-03",
   "slug": "inspired-by-lisp-to-get-ruby-to-talk-python",
-  "source_url": "http://archive.org/details/pyconza2014-inspired-by-lisp",
   "speakers": [
     "Martin Pretorius"
   ],

--- a/pycon-za-2014/videos/ipython-as-a-tool-for-teaching-and-learning.json
+++ b/pycon-za-2014/videos/ipython-as-a-tool-for-teaching-and-learning.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-02",
   "slug": "ipython-as-a-tool-for-teaching-and-learning",
-  "source_url": "http://archive.org/details/pyconza2014-ipython-for-teaching-and-learning",
   "speakers": [
     "Laura Richter"
   ],

--- a/pycon-za-2014/videos/ipython-notebook.json
+++ b/pycon-za-2014/videos/ipython-notebook.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-02",
   "slug": "ipython-notebook",
-  "source_url": "http://archive.org/details/pyconza2014-ipython-notebook",
   "speakers": [
     "Tobie Nortje"
   ],

--- a/pycon-za-2014/videos/large-scale-data-processing-with-python-and-apach.json
+++ b/pycon-za-2014/videos/large-scale-data-processing-with-python-and-apach.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-02",
   "slug": "large-scale-data-processing-with-python-and-apach",
-  "source_url": "http://archive.org/details/pyconza2014-large-scale-data-processing",
   "speakers": [
     "Nick Pentreath"
   ],

--- a/pycon-za-2014/videos/lightning-talks-17.json
+++ b/pycon-za-2014/videos/lightning-talks-17.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-02",
   "slug": "lightning-talks-17",
-  "source_url": "http://archive.org/details/pyconza2014-lightning-talks",
   "speakers": [],
   "summary": "Lightning Talks are fun, short, five-minute (or less) talks. Ideally\neach talk should make a single point, often in a fun, quirky or\nover-the-top way.\n",
   "tags": [

--- a/pycon-za-2014/videos/monkeying-around-with-twisted.json
+++ b/pycon-za-2014/videos/monkeying-around-with-twisted.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-03",
   "slug": "monkeying-around-with-twisted",
-  "source_url": "http://archive.org/details/pyconza2014-monkeying-with-twisted",
   "speakers": [
     "Richard Spiers"
   ],

--- a/pycon-za-2014/videos/practical-testing.json
+++ b/pycon-za-2014/videos/practical-testing.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-03",
   "slug": "practical-testing",
-  "source_url": "http://archive.org/details/pyconza2014-practical-testing",
   "speakers": [
     "Jeremy Thurgood"
   ],

--- a/pycon-za-2014/videos/pyconza-2014-closing-remarks.json
+++ b/pycon-za-2014/videos/pyconza-2014-closing-remarks.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-03",
   "slug": "pyconza-2014-closing-remarks",
-  "source_url": "http://archive.org/details/pyconza2014-closing",
   "speakers": [
     "Simon Cross"
   ],

--- a/pycon-za-2014/videos/python-at-the-observatory-old-telescopes-new-i.json
+++ b/pycon-za-2014/videos/python-at-the-observatory-old-telescopes-new-i.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-03",
   "slug": "python-at-the-observatory-old-telescopes-new-i",
-  "source_url": "http://archive.org/details/pyconza2014-python-at-the-observatory",
   "speakers": [
     "Carel van Gend; Briehan Lombaard"
   ],

--- a/pycon-za-2014/videos/python-in-debian-ubuntu.json
+++ b/pycon-za-2014/videos/python-in-debian-ubuntu.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-03",
   "slug": "python-in-debian-ubuntu",
-  "source_url": "http://archive.org/details/pyconza2014-python-in-debian",
   "speakers": [
     "Stefano Rivera"
   ],

--- a/pycon-za-2014/videos/python-in-the-context-of-a-start-up-the-good-th.json
+++ b/pycon-za-2014/videos/python-in-the-context-of-a-start-up-the-good-th.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-03",
   "slug": "python-in-the-context-of-a-start-up-the-good-th",
-  "source_url": "http://archive.org/details/pyconza2014-python-in-a-start-up",
   "speakers": [
     "Adam Jorgensen"
   ],

--- a/pycon-za-2014/videos/reaching-beyond-the-web.json
+++ b/pycon-za-2014/videos/reaching-beyond-the-web.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-03",
   "slug": "reaching-beyond-the-web",
-  "source_url": "http://archive.org/details/pyconza2014-reaching-beyond-the-web",
   "speakers": [
     "Vinod Kurup"
   ],

--- a/pycon-za-2014/videos/the-earth-is-not-flat-and-other-heresies.json
+++ b/pycon-za-2014/videos/the-earth-is-not-flat-and-other-heresies.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-02",
   "slug": "the-earth-is-not-flat-and-other-heresies",
-  "source_url": "http://archive.org/details/pyconza2014-earth-is-not-flat",
   "speakers": [
     "Allison Randal"
   ],

--- a/pycon-za-2014/videos/the-elephant-in-the-web-application.json
+++ b/pycon-za-2014/videos/the-elephant-in-the-web-application.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-02",
   "slug": "the-elephant-in-the-web-application",
-  "source_url": "http://archive.org/details/pyconza2014-elephant-in-the-web-app",
   "speakers": [
     "Iwan Vosloo"
   ],

--- a/pycon-za-2014/videos/using-python-in-blender.json
+++ b/pycon-za-2014/videos/using-python-in-blender.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-02",
   "slug": "using-python-in-blender",
-  "source_url": "http://archive.org/details/pyconza2014-python-in-blender",
   "speakers": [
     "Albert Nel"
   ],

--- a/pycon-za-2014/videos/what-i-learned-about-python-and-about-guidos-t.json
+++ b/pycon-za-2014/videos/what-i-learned-about-python-and-about-guidos-t.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-03",
   "slug": "what-i-learned-about-python-and-about-guidos-t",
-  "source_url": "http://archive.org/details/pyconza2014-python-ideas",
   "speakers": [
     "David Mertz"
   ],

--- a/pycon-za-2014/videos/writing-python-code-to-decide-an-election.json
+++ b/pycon-za-2014/videos/writing-python-code-to-decide-an-election.json
@@ -9,7 +9,6 @@
   "quality_notes": "",
   "recorded": "2014-10-02",
   "slug": "writing-python-code-to-decide-an-election",
-  "source_url": "http://archive.org/details/pyconza2014-code-to-decide-election",
   "speakers": [
     "Peter Lubell-Doughtie"
   ],


### PR DESCRIPTION
* Files in https://github.com/pytube/data/commit/41f0966c07467d428c8076423e07448872691532 don't contain any valid link. I only erase "source_url" field. 
* Files in https://github.com/pytube/data/commit/ba137cc79b8e7b1f2169b70ace4cdaac0080ede9 have a "source_url" with the string 'archive.org' in and ist value is the beginning of an "url" field. The two fields are not exact bout point to the same archive.org object.