### PR TITLE
Add djangocon-eu-2016 videos

### DIFF
--- a/.schemas/video.json
+++ b/.schemas/video.json
@@ -122,7 +122,6 @@
     "description",
     "speakers",
     "recorded",
-    "thumbnail_url",
     "title",
     "videos"
   ],

--- a/djangocon-eu-2016/category.json
+++ b/djangocon-eu-2016/category.json
@@ -1,0 +1,6 @@
+{
+  "description": "",
+  "start_date": "2016-03-30",
+  "title": "DjangoCon Europe 2016",
+  "url": "https://2016.djangocon.eu/"
+}

--- a/djangocon-eu-2016/videos/a-brief-history-of-channels.json
+++ b/djangocon-eu-2016/videos/a-brief-history-of-channels.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/7>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/a-brief-history-of-channels-by-andrew-godwin/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-31",
+  "speakers": [
+    "Andrew Godwin"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "A Brief History of Channels",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/h643dwrafs"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/best-practices-for-scaling-django.json
+++ b/djangocon-eu-2016/videos/best-practices-for-scaling-django.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/16>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/best-practices-for-scaling-django-by-anton-pirker/>`_.",
+  "language": "eng",
+  "recorded": "2016-04-01",
+  "speakers": [
+    "Anton Pirker"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "Best practices for scaling Django",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/pfyny8z6fx"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/beyond-web-2-0-django-and-python-in-the-modern-web-ecosystem.json
+++ b/djangocon-eu-2016/videos/beyond-web-2-0-django-and-python-in-the-modern-web-ecosystem.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/5>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/beyond-web-2-0-django-and-python-in-the-modern-web-ecosystem-by-russell-keith-magee/>`_.",
+  "language": "eng",
+  "recorded": "2016-04-01",
+  "speakers": [
+    "Russell Keith-Magee"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "Beyond Web 2.0 - Django and Python in the modern web ecosystem",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/w5dpd2z3ym"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/building-a-non-relational-backend-for-the-orm.json
+++ b/djangocon-eu-2016/videos/building-a-non-relational-backend-for-the-orm.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/3>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/building-a-non-relational-backend-for-the-orm-by-adam-alton/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-31",
+  "speakers": [
+    "Adam Alton"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "Building A Non-Relational Backend For The ORM",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/7pcv7mvo9r"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/django-and-reactjs-the-good-the-bad-and-the-ugly.json
+++ b/djangocon-eu-2016/videos/django-and-reactjs-the-good-the-bad-and-the-ugly.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/12>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/django-and-reactjs-the-good-the-bad-and-the-ugly-by-tomas-ehrlich/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-30",
+  "speakers": [
+    "Tom\u00e1\u0161 Ehrlich"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "Django and ReactJS: The good, the bad and the ugly",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/niwcwtlg5x"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/django-microservices-made-easy.json
+++ b/djangocon-eu-2016/videos/django-microservices-made-easy.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/20>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/django-microservices-made-easy-by-paul-hallett/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-31",
+  "speakers": [
+    "Paul Hallett"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "Django Microservices Made Easy",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/dwlenrttup"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/don-t-be-afraid-of-writing-migrations.json
+++ b/djangocon-eu-2016/videos/don-t-be-afraid-of-writing-migrations.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/4>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/dont-be-afraid-of-writing-migrations-by-markus-holtermann/>`_.",
+  "language": "eng",
+  "recorded": "2016-04-01",
+  "speakers": [
+    "Markus Holtermann"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "Don't be afraid of writing migrations",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/h1t41x7bok"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/from-intern-to-professional-developer-advice-on-a-mid-career-pivot.json
+++ b/djangocon-eu-2016/videos/from-intern-to-professional-developer-advice-on-a-mid-career-pivot.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/8>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/from-intern-to-professional-developer-advice-on-a-mid-career-pivot-by-rebecca-conley/>`_.",
+  "language": "eng",
+  "recorded": "2016-04-01",
+  "speakers": [
+    "Rebecca Conley"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "From Intern to Professional Developer: Advice on a Mid-Career Pivot",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/ycgslzq0em"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/going-with-the-flow-with-django-admin.json
+++ b/djangocon-eu-2016/videos/going-with-the-flow-with-django-admin.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/14>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/going-with-the-flow-with-django-admin-by-maria-lowas-rzechonek/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-30",
+  "speakers": [
+    "Maria Lowas-Rzechonek"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "Going with the flow with Django Admin",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/tp4i5zlvco"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/healthy-minds-in-a-healthy-community.json
+++ b/djangocon-eu-2016/videos/healthy-minds-in-a-healthy-community.json
@@ -1,0 +1,19 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/13>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/healthy-minds-in-a-healthy-community-by-erik-romijn-and-mikey-ariel/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-30",
+  "speakers": [
+    "Erik Romijn",
+    "Mikey Ariel"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "Healthy Minds in a Healthy Community",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/ap44pmhqcb"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/hermione-granger-and-the-wizard-information-system.json
+++ b/djangocon-eu-2016/videos/hermione-granger-and-the-wizard-information-system.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/6>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/hermione-granger-and-the-wizard-information-system-by-lacey-williams-henschel/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-31",
+  "speakers": [
+    "Lacey Williams Henschel"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "Hermione Granger and the Wizard Information System",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/5yy4ust1ol"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/how-to-upgrade-to-the-newest-and-shiniest-django.json
+++ b/djangocon-eu-2016/videos/how-to-upgrade-to-the-newest-and-shiniest-django.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/24>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/how-to-upgrade-to-the-newest-and-shiniest-django-by-susan-tan/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-30",
+  "speakers": [
+    "Susan Tan"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "How to Upgrade to the Newest and Shiniest Django",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/0hnokmkwvy"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/http-2-why-upgrading-the-web.json
+++ b/djangocon-eu-2016/videos/http-2-why-upgrading-the-web.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/2>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/http2-why-upgrading-the-web-by-quentin-adam/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-31",
+  "speakers": [
+    "Quentin Adam"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "HTTP/2: why upgrading the web?",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/4dhu06wufj"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/introducing-django-to-the-foreign-world.json
+++ b/djangocon-eu-2016/videos/introducing-django-to-the-foreign-world.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/21>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/introducing-django-to-the-foreign-world-by-bashar-al-abdulhadi/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-31",
+  "speakers": [
+    "Bashar Al-Abdulhadi"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "Introducing Django To The Foreign World",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/k3icisez2z"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/iot-with-django-from-hackathon-to-production.json
+++ b/djangocon-eu-2016/videos/iot-with-django-from-hackathon-to-production.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/9>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/iot-with-django-from-hackathon-to-production-by-anna-schneider/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-31",
+  "speakers": [
+    "Anna Schneider"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "IoT with Django: From hackathon to production",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/6rs7itpjpf"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/keynote-the-art-of-programming.json
+++ b/djangocon-eu-2016/videos/keynote-the-art-of-programming.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/22>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/keynote-the-art-of-programming-by-erika-heidi/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-31",
+  "speakers": [
+    "Erika Heidi"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "Keynote: The Art of Programming",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/rgz8fzqy4n"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/learning-django-learning-french.json
+++ b/djangocon-eu-2016/videos/learning-django-learning-french.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/15>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/learning-django-learning-french-by-nicole-harris/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-30",
+  "speakers": [
+    "Nicole Harris"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "Learning Django, Learning French",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/tzu957oa60"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/let-s-talk-geo-adding-the-where-to-your-django-project.json
+++ b/djangocon-eu-2016/videos/let-s-talk-geo-adding-the-where-to-your-django-project.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/19>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/lets-talk-geo-adding-the-where-to-your-django-project-by-corryn-smith/>`_.",
+  "language": "eng",
+  "recorded": "2016-04-01",
+  "speakers": [
+    "Corryn Smith"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "Let's Talk Geo: Adding the 'Where' to Your Django Project",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/iswyxszuh8"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/lightning-talks-day-1.json
+++ b/djangocon-eu-2016/videos/lightning-talks-day-1.json
@@ -1,0 +1,16 @@
+{
+  "description": "This video is hosted by `opbeat.com <http://opbeat.com/community/posts/lightning-talks-day-1/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-30",
+  "speakers": [],
+  "tags": [
+    "django"
+  ],
+  "title": "Lightning talks, day 1",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/7vr4gydjb4"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/lightning-talks-day-2.json
+++ b/djangocon-eu-2016/videos/lightning-talks-day-2.json
@@ -1,0 +1,16 @@
+{
+  "description": "This video is hosted by `opbeat.com <http://opbeat.com/community/posts/lightning-talks-day-2/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-31",
+  "speakers": [],
+  "tags": [
+    "django"
+  ],
+  "title": "Lightning talks, day 2",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/21hz7hsp5j"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/lightning-talks-day-3.json
+++ b/djangocon-eu-2016/videos/lightning-talks-day-3.json
@@ -1,0 +1,16 @@
+{
+  "description": "This video is hosted by `opbeat.com <http://opbeat.com/community/posts/lightning-talks-day-3/>`_.",
+  "language": "eng",
+  "recorded": "2016-04-01",
+  "speakers": [],
+  "tags": [
+    "django"
+  ],
+  "title": "Lightning talks, day 3",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/pfcwlbbtyi"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/rub-a-dub-rubber-duck-dont-be-afraid-to-debug.json
+++ b/djangocon-eu-2016/videos/rub-a-dub-rubber-duck-dont-be-afraid-to-debug.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/1>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/rub-a-dub-rubber-duck-dont-be-afraid-to-debug-by-anna-ossowski/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-30",
+  "speakers": [
+    "Anna Ossowski"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "Rub-a-Dub Rubber Duck: Don\u2019t Be Afraid to Debug!",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/fq4l1g2b64"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/safe-ish-by-default-the-django-security-model-and-how-to-make-it-better.json
+++ b/djangocon-eu-2016/videos/safe-ish-by-default-the-django-security-model-and-how-to-make-it-better.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/23>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/safe-ish-by-default-the-django-security-model-and-how-to-make-it-better-by-philip-james/>`_.",
+  "language": "eng",
+  "recorded": "2016-04-01",
+  "speakers": [
+    "Philip James"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "Safe-Ish by Default: The Django Security Model and How to Make it Better",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/gn5e8nhk6y"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/the-front-end-revolution.json
+++ b/djangocon-eu-2016/videos/the-front-end-revolution.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/25>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/the-front-end-revolution-by-claudina-sarahe/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-30",
+  "speakers": [
+    "Claudina Sarahe"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "The Front-End Revolution",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/xt9yzwcy6l"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/the-power-and-responsibility-of-unicode-adoption.json
+++ b/djangocon-eu-2016/videos/the-power-and-responsibility-of-unicode-adoption.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/11>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/the-power-and-responsibility-of-unicode-adoption-by-katie-mclaughlin/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-31",
+  "speakers": [
+    "Katie McLaughlin"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "The Power \u26a1\ufe0f and Responsibility \ud83d\ude13 of Unicode Adoption \u2728",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/s0jsm9w040"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/to-mock-or-not-to-mock-that-is-the-question.json
+++ b/djangocon-eu-2016/videos/to-mock-or-not-to-mock-that-is-the-question.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/18>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/to-mock-or-not-to-mock-that-is-the-question-by-ana-balica/>`_.",
+  "language": "eng",
+  "recorded": "2016-03-30",
+  "speakers": [
+    "Ana Balica"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "To mock, or not to mock, that is the question",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/b057b7b9jr"
+    }
+  ]
+}

--- a/djangocon-eu-2016/videos/using-django-with-service-workers.json
+++ b/djangocon-eu-2016/videos/using-django-with-service-workers.json
@@ -1,0 +1,18 @@
+{
+  "description": "You can find more about this talk on `djangocon.eu <https://2016.djangocon.eu/speakers/10>`_. This video is hosted by `opbeat.com <http://opbeat.com/community/posts/using-django-with-service-workers-by-adrian-holovaty/>`_.",
+  "language": "eng",
+  "recorded": "2016-04-01",
+  "speakers": [
+    "Adrian Holovaty"
+  ],
+  "tags": [
+    "django"
+  ],
+  "title": "Using Django with service workers",
+  "videos": [
+    {
+      "type": "wistia",
+      "url": "https://fast.wistia.com/embed/iframe/s1hv4962pm"
+    }
+  ]
+}


### PR DESCRIPTION
As we don't have access to the thumbnails yet, this also makes the
respective property in the video schema optional.

The code to extract the video data is available on https://gist.github.com/zerok/c3c04bf116edb97868df64d8dbf7941a

This closes #110 