### PR TITLE
Add two talks from WriteTheDocs NA 2014

### DIFF
--- a/writethedocs-2014/category.json
+++ b/writethedocs-2014/category.json
@@ -1,0 +1,4 @@
+{
+  "description": "Write the Docs is a series of conferences and local meetups focused on all things related to software documentation.  Write the Docs 2014 was held on May 5-6 2014 in Portland, Oregon.",
+  "title": "Write the Docs 2014"
+}

--- a/writethedocs-2014/videos/documentation-at-scale.json
+++ b/writethedocs-2014/videos/documentation-at-scale.json
@@ -1,0 +1,19 @@
+{
+  "description": "Information is powerful \u2014 every day we see it transform the world around us.\n\nDocumentation doesn't always have to be about a software workflow or open source project \u2014 it can be used to develop and convey ideas much larger than yourself. Information architecture is a powerful tool for developing ideas over time. It enables us to evolve and distill information at a much larger scale than a single person or team could ever achieve on their own.\n\nTake these concepts, and apply open source workflow tools like GitHub's Pull Requests and Write the Docs, and the distributed evolution of ideas and information has never been more accessible.\n\nWe'll explore these concepts, learn how to foster a community of distributed contributors, encourage contributions early on, and more.\n\nPython-Guide.org will be used as an example, a Python-specific knowledge base written by 168 people and accessed by over 50,000 people every month.",
+  "language": "eng",
+  "recorded": "2014-05-05",
+  "speakers": [
+    "Kenneth Reitz"
+  ],
+  "tags": [
+    "documentation"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/zhZOGST52ds/hqdefault.jpg",
+  "title": "Documentation at Scale",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=zhZOGST52ds"
+    }
+  ]
+}

--- a/writethedocs-2014/videos/documenting-domain-specific-knowledge.json
+++ b/writethedocs-2014/videos/documenting-domain-specific-knowledge.json
@@ -1,0 +1,19 @@
+{
+  "description": "Most of my career as a software engineer, I've written documentation for very general purpose tools, where users' had an existing familiarity. For the last six months I've been working on a cryptography library, a domain most developers are ignorant of. We set out with the goal of making our documentation accessible to any developer, regardless of previous cryptographic experience, which presents unique challenges. This talk will dive into what these challenges are, and how we try to solve them.",
+  "language": "eng",
+  "recorded": "2014-05-05",
+  "speakers": [
+    "Alex Gaynor"
+  ],
+  "tags": [
+    "documentation"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/x93bYLu88UE/hqdefault.jpg",
+  "title": "Documenting Domain Specific Knowledge",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=x93bYLu88UE"
+    }
+  ]
+}


### PR DESCRIPTION
This adds two talks from the 2014 WriteTheDocs that are relevant to Python.  I haven't watched every talk, so I searched for 'python' in the description and also looked for names I recognized from the Python community.

I also looked at the other WriteTheDocs conferences (NA 2015, the EU conferences) and didn't see anything else that needed to be added.  I recognized some speaker names, but those talks have generally also been given at a DjangoCon.  Unless we're trying to be utter completists, we therefore don't need to duplicate these talks and incorporating WriteTheDocs is completed.
